### PR TITLE
feat(domain): introduce domain crate for business logic

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working on the Stadera repository.
+
+## Project
+
+**Stadera** — Personal weight tracking & nutrition coaching API, integrated with 
+Withings smart scales. Named after the *stadera romana*, the ancient steelyard balance.
+
+Backend-only repo. Frontend lives in a separate `stadera-web` repo (Next.js).
+
+## Working agreement
+
+The repo owner (Michele) is implementing the backend himself with Claude acting 
+as **mentor and reviewer**, not code generator. When asked to help with backend:
+
+1. Propose a multi-step plan and wait for validation before executing
+2. Ask clarifying questions when anything is ambiguous
+3. Do not write production Rust code unsolicited — guide, review, suggest patterns
+4. Exception: when explicitly asked to implement, or when writing tests/docs/CI, 
+   proceed directly
+5. The frontend (separate repo) is fully Claude-implemented when that repo exists
+
+Respond in Italian when addressed in Italian, English otherwise.
+
+## Architecture
+
+Cargo workspace, crates under `crates/`:
+
+| Crate           | Responsibility                                        | Status |
+| --------------- | ----------------------------------------------------- | ------ |
+| `domain`        | Pure business logic. Types, validation, calculations. No I/O. | ✅ M2 |
+| `storage`       | Postgres repository pattern, sqlx migrations.         | planned M3 |
+| `withings`      | Withings OAuth2 + Health Mate API client.             | planned M4 |
+| `notifications` | Pushover + Resend (email) clients.                    | planned M6 |
+| `api`           | axum HTTP server binary. utoipa for OpenAPI.          | scaffolded, expanded M5 |
+| `jobs`          | Cron binary for daily sync + weekly digest.           | planned M4/M6 |
+
+**Data flow**: Withings → `jobs` (sync) → Postgres → `api` → `stadera-web` frontend.  
+**Auth model**: Single-tenant with real OAuth Google. Schema is multi-user-ready 
+(every table has `user_id`), but only one user is exposed. No API keys.
+
+**Target deployment**: GCP — Cloud Run (api), Cloud Run Jobs + Scheduler (jobs), 
+Neon Postgres, Secret Manager. Terraform for IaC. Single env (no dev/prod split).
+
+## Rust conventions (strict)
+
+- Toolchain pinned in `rust-toolchain.toml`. Never bypass it.
+- Edition 2024 across the workspace via `edition.workspace = true`.
+- Centralize shared deps in `[workspace.dependencies]` — crates inherit with 
+  `dep.workspace = true`.
+- **No `unwrap()` / `panic!()` / `expect()` in non-test code.** Use `Result` 
+  with `thiserror` for library crates, `anyhow` for binaries.
+- **No raw `f64`/`i64`/etc. for domain values.** Use newtypes with validating 
+  constructors (e.g. `Weight::new(f64) -> Result<Self, DomainError>`).
+- **Do not derive `Eq`/`Hash` on types containing `f64`** — only `PartialEq`/`PartialOrd`.
+- **Never call `Utc::now()` / `SystemTime::now()` inside `domain/`**. Inject 
+  time as a parameter for testability.
+- Re-export public types at crate root (`lib.rs`) for ergonomic imports.
+- Prefer `TryFrom` for fallible conversions, `From` for infallible.
+- Async runtime is Tokio. Async-in-trait via `async_trait` crate when needed 
+  (until stabilized enough to drop it).
+
+## Commands
+
+Before any commit or PR, these must pass locally:
+
+```bash

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,150 @@
+# Stadera — Architecture & Roadmap
+
+Living document. Single source of truth for cross-milestone decisions that are **not** in the code yet or that would require digging through conversations to reconstruct. Code-level conventions live in `.claude/CLAUDE.md`.
+
+## Project
+
+**Stadera** — Personal weight-tracking and nutrition-coaching app backed by Withings smart scales. Named after the *stadera romana*, the ancient Roman steelyard balance.
+
+**Primary goal**: controlled 10 kg weight loss (83 → 73 kg, height 1.73 m) with personalized kcal/protein plan + daily/weekly notifications.
+**Secondary goal**: learn cloud-native Rust properly while building something useful.
+
+**Owner** — Michele Bellitti. Single-user app. Repo is private.
+
+## Repositories
+
+- `stadera` (this repo) — Rust backend, monorepo via Cargo workspace.
+- `stadera-web` (not yet created) — Next.js frontend. To be scaffolded in M5 by Claude; architectural choices consulted with owner.
+
+## Workspace layout
+
+```
+stadera/
+├── crates/
+│   ├── api/           # axum HTTP server — scaffolded, built out in M5
+│   ├── domain/        # pure business logic — M2 (in review as PR #2)
+│   ├── storage/       # Postgres repos + sqlx — planned M3
+│   ├── withings/      # Withings OAuth2 + API client — planned M4
+│   ├── notifications/ # Pushover + Resend — planned M6
+│   └── jobs/          # cron binary (daily sync, weekly digest) — planned M4/M6
+├── .github/workflows/
+├── .claude/           # Claude memory + docs (this file lives here)
+├── Cargo.toml         # workspace manifest
+├── rust-toolchain.toml
+├── release-please-config.json
+└── …
+```
+
+## Stack
+
+| Layer | Choice | Why |
+|---|---|---|
+| Language | Rust edition 2024, toolchain 1.85+ | Statically-typed domain, async mature, learning target |
+| Async runtime | Tokio | De-facto standard |
+| HTTP | `axum` | Tower ecosystem, ergonomic, well-integrated |
+| DB | Postgres (Neon serverless) | Free tier, scale-to-zero, SQL familiar |
+| DB client | `sqlx` | Compile-time SQL check, async, migrations built-in |
+| OpenAPI | `utoipa` (code-first) + Swagger UI | Schema from types, zero duplication |
+| Errors | `thiserror` (libs) + `anyhow` (bins) | Idiomatic split |
+| Serde | `serde` + `serde_json` | De-facto |
+| Time | `chrono` (with `serde`) | Richer API than `time` for this use case |
+| Tracing | `tracing` + `tracing-subscriber` | Structured logs, span support |
+| Tests | built-in + `proptest` | Property testing for domain invariants |
+
+## Deployment target (M7)
+
+| Concern | Choice |
+|---|---|
+| Backend runtime | Cloud Run (scale-to-zero) |
+| Cron | Cloud Run Jobs + Cloud Scheduler |
+| Database | Neon Postgres (serverless, free tier) |
+| Secrets | GCP Secret Manager |
+| IaC | Terraform |
+| Frontend | Vercel |
+| Logging | Native GCP (no Sentry for now) |
+| Observability | Cloud Logging / Cloud Trace (TBD) |
+| Environments | Single env — no dev/prod split. Feature branches test locally. |
+
+## Roadmap
+
+| ID | Name | Status | Notes |
+|---|---|---|---|
+| M1 | Foundations | ✅ Done | Workspace, CI, release-please, conventional commits |
+| M2 | Domain core | ⏳ In review | PR #2 open. 3 blockers to fix — see `reviews/pr-2.md` |
+| M3 | Storage | ⏸ Next | Postgres schema, sqlx migrations, repository pattern, Docker compose for local dev |
+| M4 | Withings integration | 📋 Planned | OAuth2 flow, token refresh, API client, sync binary. Multi-tenant DB schema ready |
+| M5 | API + Frontend | 📋 Planned | axum endpoints (`/today`, `/trend`, `/history`), OAuth Google auth middleware, utoipa/Swagger. `stadera-web` repo scaffolded |
+| M6 | Notifications | 📋 Planned | Pushover daily job, Resend weekly digest (Apple-weekly-summary style) |
+| M7 | Cloud deploy | 📋 Planned | Terraform, GitHub Actions deploy, Dockerfile multi-stage, Vercel for frontend |
+
+## Key architectural decisions
+
+### Single-tenant but multi-tenant-ready schema
+
+- Auth: real OAuth Google with a single exposed user. No API keys.
+- Every DB table has `user_id` from day 1.
+- Rationale: avoid a schema migration if/when the app is ever opened to others. Cost of `user_id` columns is negligible; cost of retrofitting them later is high.
+
+### Domain crate isolation (M2)
+
+- Pure business logic, zero I/O.
+- No `Utc::now()` / `SystemTime::now()` — time is injected as parameter for testability.
+- All domain values are newtypes with validating constructors. No raw `f64`/`i64` at the domain boundary.
+- Tests in `tests/` dir (integration-test style) instead of inline `#[cfg(test)]` — forces testing through the public API.
+
+### Storage layer (M3 decisions pending)
+
+Open questions to resolve when starting M3:
+- Repository pattern via traits (for testability) vs. direct `sqlx` calls in services?
+- Migration strategy: `sqlx migrate` CLI vs. a lib-level migration runner at startup?
+- Connection pooling config — `sqlx::PgPool` defaults or custom sizing for Cloud Run (scale-to-zero → cold starts)?
+- Docker compose for local Postgres 16? (probably yes)
+
+### Notifications (M6 decisions pending)
+
+- Pushover daily: what time? Morning (6-8) before the workout, or evening with yesterday's summary?
+- Weekly digest email: Sunday evening or Monday morning?
+- Email template: HTML with MJML, or plain-ish styled?
+
+### Cloud (M7 decisions pending)
+
+- Single GCP project or separate for Stadera?
+- Custom domain from day 1 or `.run.app` URL?
+- Staging/preview envs on Vercel previews only, backend always single-env?
+
+## Conventions (quick reference)
+
+Full details in `.claude/CLAUDE.md`. Key points for fast recall:
+
+- **Trunk-based**: `main` always deployable. Short-lived feature branches.
+- **Branch naming**: `<type>/<short-desc>` — e.g. `feat/storage-schema`, `fix/serde-validation`, `chore/pr-template`.
+- **Conventional Commits**: enforced. Squash merge: 1 PR = 1 commit on `main`.
+- **release-please**: on push to `main`, automatic changelog + version bump + GitHub Release.
+- **CI gate**: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --all` must all pass.
+- **No `unwrap()` / `panic!()` / `expect()` in non-test code.**
+- **Review flow**: Michele implements backend; Claude reviews. Claude implements frontend (M5+), consults on architecture.
+
+## Mentoring contract
+
+This is the working agreement between Michele and Claude (mirrored in `.claude/CLAUDE.md`):
+
+1. Claude is mentor + reviewer for backend, **not** code generator.
+2. Every non-trivial task → multi-step plan validated by owner before execution.
+3. Clarifying questions over guesswork.
+4. Exception: docs / tests / CI / markdown / config — Claude can proceed directly.
+5. For frontend Next.js (M5+): Claude implements, consults on architecture.
+6. Italian in conversation when asked in Italian; English in code, commits, docs, PR templates (repo-level lingua franca).
+
+## Living memory
+
+Cross-milestone facts worth remembering:
+
+- Owner's starting metrics (as of project start): weight 83 kg, height 1.73 m, target 73 kg.
+- Protein target convention: typically 1.6–2.0 g / kg bodyweight during cut.
+- Deficit convention: 500 kcal/day → ~0.5 kg/week (sustainable floor).
+- Medical safety floor (adult male): 1500 kcal/day minimum. For adult female: 1200.
+- Withings API is the only data ingestion source. No manual weight entry endpoint planned.
+
+---
+
+Last updated: 2026-04-24. Review and prune when a milestone closes or a decision becomes code.

--- a/.claude/docs/reviews/pr-2.md
+++ b/.claude/docs/reviews/pr-2.md
@@ -1,0 +1,162 @@
+# PR #2 Review — `feat(domain): introduce domain crate`
+
+**URL**: https://github.com/MicheleBellitti/Stadera/pull/2
+**Branch**: `feature/domain-logic`
+**HEAD SHA**: `125fad8001c0b7f5b2b2dfee1228d69c0c5f11d5`
+**Review date**: 2026-04-24
+**Status**: ⏳ blockers open — not mergeable yet
+
+## Build signal
+
+- `cargo fmt --all -- --check` → ✅
+- `cargo clippy --all-targets --all-features -- -D warnings` → ✅
+- `cargo test --all` → ✅ 45 tests pass
+- `cargo doc --no-deps` → ✅
+
+## Blockers (3)
+
+### B1 — `#[derive(Deserialize)]` bypasses newtype validation
+
+**Location**: `crates/domain/src/units.rs:8,41,74,107`
+
+Tuple-struct `pub struct Weight(f64)` with `#[derive(Deserialize)]` deserializes any `f64` directly, skipping `Weight::new()`. Same for `BodyFatPercent`, `LeanMass`, `Height`.
+
+Breaks: `.claude/CLAUDE.md` invariant "No raw f64 for domain values".
+
+Reproduction: `serde_json::from_str::<Weight>("-10.0")` returns `Ok(Weight(-10.0))` instead of `Err`.
+
+**Fix** (per type):
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct Weight(f64);
+```
+No `into = "f64"` needed — default `Serialize` for single-field tuple structs is already transparent.
+No `impl From<Weight> for f64` needed.
+`TryFrom<f64>` already exists on all 4 types.
+`DomainError: Display` already satisfied via `thiserror::Error` derive.
+
+Regression test (1 per type):
+```rust
+#[test]
+fn weight_deserialize_rejects_invalid() {
+    assert!(serde_json::from_str::<Weight>("-10.0").is_err());
+    assert!(serde_json::from_str::<Weight>("600.0").is_err());
+    assert!(serde_json::from_str::<Weight>("null").is_err());
+}
+```
+Requires `serde_json` in `[dev-dependencies]`.
+
+### B2 — `README:md` filename has `:` instead of `.`
+
+**Location**: `crates/domain/README:md`
+
+Typo. No tool in the Rust ecosystem (cargo, crates.io) or git host (GitHub, GitLab) recognizes this as a README. Crate documentation is effectively invisible.
+
+**Fix**: `git mv "crates/domain/README:md" "crates/domain/README.md"`
+
+### B3 — `.vscode/settings.json` committed, `.gitignore` too minimal
+
+**Location**: `.vscode/settings.json`, `.gitignore`
+
+`.gitignore` contains only `/target`. `.vscode/settings.json` contains personal `autoApprove` config — IDE noise.
+
+**Fix**:
+1. Extend `.gitignore`:
+   ```
+   /target
+   /.vscode/
+   /.idea/
+   .DS_Store
+   *.swp
+   *.swo
+   ```
+2. `git rm --cached .vscode/settings.json`
+
+## Concerns (12) — design decisions, owner choice
+
+Grouped by theme.
+
+### Energy / daily target
+
+- **C1** — `DailyTarget.kcal` can be negative with no validation. `crates/domain/src/energy.rs:18-28`. Options: fail-fast with `Result<_, DomainError>` + `UnsafeCalorieTarget` variant (recommended); clamp to 1500 (adult male min); validate `Deficit` newtype upstream. Floor 100 rejected — no medical meaning.
+- **C4** — `ActivityLevel` missing `ExtraActive` (1.9). `crates/domain/src/user.rs:13-18`. 4 canonical levels out of 5. Intentional MVP gap or omission? Document in doc-comment either way.
+
+### No-raw-f64 convention violations
+
+- **C2** — Derived values return raw `f64`, breaking the repo-wide "newtypes for domain values" rule:
+  - `energy.rs:4` — `bmr_katch_mcardle() -> f64`
+  - `energy.rs:8` — `tdee() -> f64`
+  - `energy.rs:13-16` — `DailyTarget { kcal: f64, protein_g: f64 }`
+  - `measurement.rs:29-32` — `fat_mass() -> Option<f64>`
+  - `measurement.rs:34-37` — `bmi() -> f64`
+
+  Decision: introduce newtypes (`Kcal`, `ProteinGrams`, `FatMass`, `Bmi`) OR explicitly document exception for derived (non-input) values.
+
+### Errors
+
+- **C3** — `DomainError::NotFinite` lacks field context. `crates/domain/src/error.rs:17-18`. Other variants carry `value`; this one doesn't. Fix: `NotFinite { field: &'static str }` or per-type variants.
+
+### Trend
+
+- **C5** — `f64::EPSILON` (~2.2e-16) as stagnation threshold in `estimate_goal_date`. `crates/domain/src/trend.rs:85`. Should be ~0.01 kg/week. Extract `STAGNANT_TREND_THRESHOLD_KG_PER_WEEK` constant.
+
+### Conventions / tooling
+
+- **C6** — `proptest = "1"` hardcoded in `crates/domain/Cargo.toml:14` instead of `[workspace.dependencies]`. Move now, M3/M4 crates will want property tests too.
+- **C7** — `release-please-config.json` does not include `crates/domain`. After merge, no CHANGELOG entry will be generated for domain. Add entry + manifest `"crates/domain": "0.1.0"`.
+- **C8** — `rust-toolchain.toml` pinned to 1.85 but CI uses `dtolnay/rust-toolchain@stable`. Choose one: pin everywhere (`@1.85`) or remove toolchain file.
+
+### Test coverage
+
+- **C9** — Gaps:
+  - `test_energy.rs` covers only `Sedentary` and `VeryActive` levels; missing `LightlyActive` and `ModeratelyActive` through full `tdee()`.
+  - `test_trend.rs` missing unordered input, same-day duplicates, `estimate_goal_date` gaining scenario (positive delta).
+  - `test_measurement.rs` uses `Utc::now()` — should use fixed timestamps like `test_trend.rs` does.
+  - No serde roundtrip tests anywhere (becomes important after B1 fix).
+
+### API shape
+
+- **C10** — `Measurement` and `UserProfile` have `pub` fields. Consumers can construct bypassing `new()`. OK now (passthrough), but future cross-field validation will be bypassed. Fix: `pub(crate)` + getters, OR document as transparent DTOs.
+- **C11** — `Sex` stored but unused by Katch-McArdle BMR. `crates/domain/src/user.rs:6-10`. If kept for future Mifflin-St Jeor fallback, document.
+- **C12** — `UserProfile::age()` with future birth_date → 0 (via `max(0) as u32`). Test doesn't pin this. Add regression test or return `Option<u32>`.
+
+## Nits (9) — cosmetic
+
+- **N1** — Remove `// WIP: …` comment in `crates/domain/src/error.rs:19`. Convert to issue if still relevant.
+- **N2** — `Clone` on `DomainError` unusual. Keep `PartialEq` for tests, drop `Clone`.
+- **N3** — `ActivityLevel::multiplier(&self)` → `multiplier(self)` (type is `Copy`). Clippy `trivially_copy_pass_by_ref`.
+- **N4** — Magic number `0.01` in `crates/domain/src/trend.rs:82`. Extract `GOAL_TOLERANCE_KG` constant.
+- **N5** — Field name `moving_average_7d` misleading (it's "average over last 7 days", not rolling window). Rename or document.
+- **N6** — 4 identical newtype blocks in `units.rs` → candidate for `macro_rules!`. Opinion, not blocker.
+- **N7** — `TryFrom<f64>` is pure delegate to `new()`. API duplication but idiomatic.
+- **N8** — `(w.value() - v).abs() < f64::EPSILON` in tests is theatrical (constructor doesn't do arithmetic). Use `assert_eq!`.
+- **N9** — `rustfmt.toml` `edition = "2021"` while workspace is `edition = "2024"`. Align.
+
+## Global repo gaps (6)
+
+Out of scope for this PR, but worth tracking:
+
+- **G1** — No `./CLAUDE.md` in root (only `.claude/CLAUDE.md`).
+- **G2** — CI missing `cargo audit` / `cargo deny`. Add workflow on schedule + on lockfile changes.
+- **G3** — CI `cargo test` without `--locked`. With `Cargo.lock` committed, add `--locked`.
+- **G4** — No MSRV matrix in CI (only `stable`). Add `1.85` job to protect edition-2024 floor.
+- **G5** — No PR template → addressed in this branch concurrently.
+- **G6** — `clippy.toml` exists but empty (0 bytes). Populate (`msrv = "1.85"`, `disallowed-methods` for `Utc::now` in domain) or remove.
+
+## Proposed follow-up structure
+
+1. **This branch, before merge**: fix B1 + B2 + B3. Minimal scope to unblock.
+2. **Follow-up PR A (immediately post-merge of M2)**: C1 (DailyTarget), C2 (derived newtypes), C3 (NotFinite context), C9 (test coverage).
+3. **Follow-up PR B (pre-M3 storage)**: C6 (proptest workspace), C7 (release-please), C8 (toolchain pin), C12 (age edge).
+4. **M7 cloud milestone**: G2, G3, G4 (CI hardening).
+5. **Opportunistic**: nits + G1, G6.
+
+## Key architectural positives (for record)
+
+- `domain` crate is correctly pure: grep confirms no `Utc::now()` / `SystemTime::now()` in `crates/domain/src/**`.
+- `Eq` / `Hash` correctly absent on all `f64`-containing types (per convention).
+- Katch-McArdle formula (`BMR = 370 + 21.6 * lean_mass_kg`) and TDEE multiplication are mathematically correct.
+- No `unwrap()` / `panic!()` / `expect()` in non-test code (grep confirmed).
+- Tests in dedicated files under `tests/` — good separation from source.
+- Property tests with `proptest` present (shallow but a start).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,122 @@
+<!--
+  PR Title: use Conventional Commits format.
+  Examples: feat(domain): add BMI newtype  |  fix(api): reject invalid weight  |  chore: bump serde
+  Types: feat, fix, refactor, chore, docs, test, ci, perf, build, style
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes and why. -->
+
+## Motivation / Context
+
+<!--
+  Why is this change needed? Link to issue, milestone (M1–M7), or discussion.
+  Delete the line that doesn't apply.
+-->
+
+- Milestone: M?
+- Closes #
+- Related: #
+
+## Type of change
+
+<!-- Tick one or more. Must match the Conventional Commits prefix in the title. -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code restructuring, no behavior change
+- [ ] `chore` — maintenance (deps, configs, tooling)
+- [ ] `docs` — documentation only
+- [ ] `test` — tests only
+- [ ] `ci` — CI / CD
+- [ ] `perf` — performance
+- [ ] `build` — build system
+- [ ] `style` — formatting only
+
+## Changes
+
+<!-- Bullet list of the main changes the reviewer should look at. -->
+
+-
+
+<details>
+<summary><b>Screenshots / Demo</b> — optional, for UI or visual changes</summary>
+
+<!-- Before / after screenshots, GIFs, terminal recordings, sample API responses, etc. -->
+
+</details>
+
+<details>
+<summary><b>Breaking changes</b> — optional, API / schema / config breaks</summary>
+
+<!--
+  - What breaks?
+  - Who is affected (api consumers, cron jobs, CLI users)?
+  - How to migrate?
+-->
+
+</details>
+
+<details>
+<summary><b>Migration notes</b> — optional, DB migrations / data backfill</summary>
+
+<!--
+  - Order of operations
+  - Downtime window (if any)
+  - Rollback plan
+-->
+
+</details>
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --all`
+- [ ] Manual verification: <!-- describe or delete -->
+
+## Checklist
+
+- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No `unwrap()`, `panic!()`, `expect()` in non-test code
+- [ ] No `Utc::now()` / `SystemTime::now()` inside `crates/domain/`
+- [ ] Domain values use newtypes, not raw `f64` / `i64`
+- [ ] New deps centralized in `[workspace.dependencies]` and inherited via `dep.workspace = true`
+- [ ] CHANGELOG handled by release-please (no manual edit)
+- [ ] Rustdoc / README / CLAUDE.md updated where relevant
+
+<details>
+<summary><b>Deployment notes</b> — optional, infra / secrets / cron</summary>
+
+<!--
+  - Terraform changes
+  - New secrets required in Secret Manager
+  - Cloud Run job schedule changes
+  - Environment variables added / removed
+-->
+
+</details>
+
+<details>
+<summary><b>Observability</b> — optional, logging / metrics / tracing</summary>
+
+<!--
+  - New log fields, spans, metrics
+  - Dashboards / alerts to update
+-->
+
+</details>
+
+<details>
+<summary><b>Follow-ups</b> — optional, known gaps left for future PRs</summary>
+
+<!--
+  Issues to open or carry-over work. Link them when created.
+-->
+
+</details>
+
+## Notes for reviewer
+
+<!-- Anything specific to focus on. Delete this section if nothing to add. -->

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "cargo clippy": true,
+        "cargo test": true
+    }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -24,16 +54,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -46,16 +118,156 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -108,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +364,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,12 +392,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -187,10 +502,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -200,6 +595,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -238,6 +639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stadera-domain"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "proptest",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +657,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -347,10 +791,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "valuable"
@@ -359,16 +815,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -378,3 +993,123 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "chrono",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/api"]
+members = ["crates/api", "crates/domain"]
 
 [workspace.package]
 edition = "2024"
@@ -8,9 +8,10 @@ license = "MIT"
 repository = "https://github.com/MicheleBellitti/stadera"
 
 [workspace.dependencies]
-# qui centralizzeremo le dep condivise in M2+
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stadera-domain"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+serde.workspace = true
+chrono.workspace = true
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -12,3 +12,4 @@ chrono.workspace = true
 
 [dev-dependencies]
 proptest = "1"
+serde_json = "1"

--- a/crates/domain/README.md
+++ b/crates/domain/README.md
@@ -1,0 +1,18 @@
+# stadera-domain
+
+Pure business logic for Stadera: types, validation, and calculations.
+No I/O, no async, no dependencies on other Stadera crates.
+
+## Key types
+
+- `Weight`, `Height`, `BodyFatPercentage`, `LeanMass` — validated newtypes
+- `Measurement` — single scale reading
+- `UserProfile` — user static data
+- `DailyTarget` — kcal + protein goals
+
+## Key functions
+
+- `tdee()` — Katch-McArdle BMR × activity multiplier
+- `daily_target()` — kcal/protein goals for a given deficit
+- `compute_trend()` — 7-day moving average and weekly delta
+- `estimate_goal_date()` — projection to goal weight

--- a/crates/domain/src/energy.rs
+++ b/crates/domain/src/energy.rs
@@ -1,0 +1,38 @@
+use crate::error::DomainError;
+use crate::units::{LeanMass, Weight};
+use crate::user::ActivityLevel;
+
+pub fn bmr_katch_mcardle(lean_mass: LeanMass) -> f64 {
+    370.0 + 21.6 * lean_mass.value()
+}
+
+pub fn tdee(lean_mass: LeanMass, activity: ActivityLevel) -> f64 {
+    bmr_katch_mcardle(lean_mass) * activity.multiplier()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DailyTarget {
+    pub kcal: f64,
+    pub protein_g: f64,
+}
+
+pub fn daily_target(
+    tdee: f64,
+    current_weight: Weight,
+    deficit_kcal: f64,
+    protein_per_kg: f64,
+) -> Result<DailyTarget, DomainError> {
+    let kcal = tdee - deficit_kcal;
+    const MIN_KCAL: f64 = 1200.0;
+    if kcal < MIN_KCAL {
+        return Err(DomainError::UnsafeCaloriTarget {
+            kcal,
+            min: MIN_KCAL,
+        });
+    }
+
+    Ok(DailyTarget {
+        kcal,
+        protein_g: current_weight.value() * protein_per_kg,
+    })
+}

--- a/crates/domain/src/error.rs
+++ b/crates/domain/src/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum DomainError {
+    #[error("invalid weight: {value} kg (expected 10..500)")]
+    InvalidWeight { value: f64 },
+
+    #[error("invalid body fat percent: {value}% (expected 2..80)")]
+    InvalidBodyFat { value: f64 },
+
+    #[error("invalid lean mass: {value} kg")]
+    InvalidLeanMass { value: f64 },
+
+    #[error("invalid height: {value} cm (expected 50..300)")]
+    InvalidHeight { value: f64 },
+
+    #[error("value is NaN or infinite")]
+    NotFinite,
+    #[error("calorie target of {kcal} kcal is below the safe minimum of {min} kcal")]
+    UnsafeCaloriTarget { kcal: f64, min: f64 },
+    // WIP: aggiungere altri errori specifici per il dominio, es. InvalidUnit, OutOfRange, etc.
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,0 +1,17 @@
+//! Stadera domain: business logic for weight tracking and nutrition.
+//!
+//! Pure functions and strongly-typed values. No I/O.
+
+pub mod energy;
+pub mod error;
+pub mod measurement;
+pub mod trend;
+pub mod units;
+pub mod user;
+
+pub use energy::DailyTarget;
+pub use error::DomainError;
+pub use measurement::Measurement;
+pub use trend::WeightTrend;
+pub use units::{BodyFatPercent, Height, LeanMass, Weight};
+pub use user::{ActivityLevel, Sex, UserProfile};

--- a/crates/domain/src/measurement.rs
+++ b/crates/domain/src/measurement.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::units::{BodyFatPercent, Height, LeanMass, Weight};
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Measurement {
+    pub taken_at: DateTime<Utc>,
+    pub weight: Weight,
+    pub body_fat: Option<BodyFatPercent>,
+    pub lean_mass: Option<LeanMass>,
+}
+
+impl Measurement {
+    pub fn new(
+        taken_at: DateTime<Utc>,
+        weight: Weight,
+        body_fat: Option<BodyFatPercent>,
+        lean_mass: Option<LeanMass>,
+    ) -> Self {
+        Self {
+            taken_at,
+            weight,
+            body_fat,
+            lean_mass,
+        }
+    }
+
+    pub fn fat_mass(&self) -> Option<f64> {
+        self.body_fat
+            .map(|bf| self.weight.value() * (bf.value() / 100.0))
+    }
+
+    pub fn bmi(&self, height: Height) -> f64 {
+        let height_m = height.value() / 100.0;
+        self.weight.value() / (height_m * height_m)
+    }
+}

--- a/crates/domain/src/trend.rs
+++ b/crates/domain/src/trend.rs
@@ -1,0 +1,95 @@
+use chrono::{NaiveDate, TimeDelta};
+
+use crate::measurement::Measurement;
+use crate::units::Weight;
+
+#[derive(Debug)]
+pub struct WeightTrend {
+    pub moving_average_7d: Option<Weight>,
+    pub weekly_delta_kg: Option<f64>,
+}
+
+pub fn compute_trend(measurements: &[Measurement]) -> WeightTrend {
+    if measurements.is_empty() {
+        return WeightTrend {
+            moving_average_7d: None,
+            weekly_delta_kg: None,
+        };
+    }
+
+    let mut sorted: Vec<&Measurement> = measurements.iter().collect();
+    sorted.sort_by_key(|m| m.taken_at);
+
+    let Some(latest) = sorted.last() else {
+        return WeightTrend {
+            moving_average_7d: None,
+            weekly_delta_kg: None,
+        };
+    };
+
+    let latest_date = latest.taken_at.date_naive();
+    let seven_days_ago = latest_date - TimeDelta::days(7);
+    let fourteen_days_ago = latest_date - TimeDelta::days(14);
+
+    let recent: Vec<f64> = sorted
+        .iter()
+        .filter(|m| m.taken_at.date_naive() > seven_days_ago)
+        .map(|m| m.weight.value())
+        .collect();
+
+    let previous: Vec<f64> = sorted
+        .iter()
+        .filter(|m| {
+            let d = m.taken_at.date_naive();
+            d > fourteen_days_ago && d <= seven_days_ago
+        })
+        .map(|m| m.weight.value())
+        .collect();
+
+    let avg_recent = if recent.is_empty() {
+        None
+    } else {
+        Some(recent.iter().sum::<f64>() / recent.len() as f64)
+    };
+
+    let avg_previous = if previous.is_empty() {
+        None
+    } else {
+        Some(previous.iter().sum::<f64>() / previous.len() as f64)
+    };
+
+    let moving_average_7d = avg_recent.and_then(|v| Weight::new(v).ok());
+
+    let weekly_delta_kg = match (avg_recent, avg_previous) {
+        (Some(r), Some(p)) => Some(r - p),
+        _ => None,
+    };
+
+    WeightTrend {
+        moving_average_7d,
+        weekly_delta_kg,
+    }
+}
+
+pub fn estimate_goal_date(
+    current: Weight,
+    goal: Weight,
+    weekly_delta_kg: f64,
+    today: NaiveDate,
+) -> Option<NaiveDate> {
+    let diff = goal.value() - current.value();
+
+    if diff.abs() < 0.01 {
+        return Some(today);
+    }
+    if weekly_delta_kg.abs() < f64::EPSILON {
+        return None;
+    }
+    if diff.signum() != weekly_delta_kg.signum() {
+        return None;
+    }
+
+    let weeks = diff / weekly_delta_kg;
+    let days = (weeks * 7.0).ceil() as i64;
+    today.checked_add_signed(TimeDelta::days(days))
+}

--- a/crates/domain/src/units.rs
+++ b/crates/domain/src/units.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::DomainError;
+
+/// Weight in kg.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct Weight(f64);
+
+impl Weight {
+    pub fn new(value: f64) -> Result<Self, DomainError> {
+        if !value.is_finite() {
+            return Err(DomainError::NotFinite);
+        }
+        if !(10.0..=500.0).contains(&value) {
+            return Err(DomainError::InvalidWeight { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for Weight {
+    type Error = DomainError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for Weight {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.1} kg", self.0)
+    }
+}
+
+/// Body fat percentage (2.0–80.0).
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct BodyFatPercent(f64);
+
+impl BodyFatPercent {
+    pub fn new(value: f64) -> Result<Self, DomainError> {
+        if !value.is_finite() {
+            return Err(DomainError::NotFinite);
+        }
+        if !(2.0..=80.0).contains(&value) {
+            return Err(DomainError::InvalidBodyFat { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for BodyFatPercent {
+    type Error = DomainError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for BodyFatPercent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.1}%", self.0)
+    }
+}
+
+/// Lean mass in kg.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct LeanMass(f64);
+
+impl LeanMass {
+    pub fn new(value: f64) -> Result<Self, DomainError> {
+        if !value.is_finite() {
+            return Err(DomainError::NotFinite);
+        }
+        if !(2.0..=300.0).contains(&value) {
+            return Err(DomainError::InvalidLeanMass { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for LeanMass {
+    type Error = DomainError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for LeanMass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.1} kg", self.0)
+    }
+}
+
+/// Height in cm.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct Height(f64);
+
+impl Height {
+    pub fn new(value: f64) -> Result<Self, DomainError> {
+        if !value.is_finite() {
+            return Err(DomainError::NotFinite);
+        }
+        if !(50.0..=300.0).contains(&value) {
+            return Err(DomainError::InvalidHeight { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for Height {
+    type Error = DomainError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for Height {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.1} cm", self.0)
+    }
+}

--- a/crates/domain/src/user.rs
+++ b/crates/domain/src/user.rs
@@ -1,0 +1,48 @@
+use chrono::{Datelike, NaiveDate};
+use serde::{Deserialize, Serialize};
+
+use crate::units::{Height, Weight};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum Sex {
+    Male,
+    Female,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum ActivityLevel {
+    Sedentary,
+    LightlyActive,
+    ModeratelyActive,
+    VeryActive,
+}
+
+impl ActivityLevel {
+    pub fn multiplier(&self) -> f64 {
+        match self {
+            Self::Sedentary => 1.2,
+            Self::LightlyActive => 1.375,
+            Self::ModeratelyActive => 1.55,
+            Self::VeryActive => 1.725,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct UserProfile {
+    pub birth_date: NaiveDate,
+    pub sex: Sex,
+    pub height: Height,
+    pub activity: ActivityLevel,
+    pub goal_weight: Weight,
+}
+
+impl UserProfile {
+    pub fn age(&self, today: NaiveDate) -> u32 {
+        let mut age = today.year() - self.birth_date.year();
+        if (today.month(), today.day()) < (self.birth_date.month(), self.birth_date.day()) {
+            age -= 1;
+        }
+        age.max(0) as u32
+    }
+}

--- a/crates/domain/tests/test_energy.rs
+++ b/crates/domain/tests/test_energy.rs
@@ -1,0 +1,47 @@
+use stadera_domain::energy::{bmr_katch_mcardle, daily_target, tdee};
+use stadera_domain::units::{LeanMass, Weight};
+use stadera_domain::user::ActivityLevel;
+
+#[test]
+fn bmr_with_60kg_lean_mass() {
+    let lm = LeanMass::new(60.0).unwrap();
+    let bmr = bmr_katch_mcardle(lm);
+    // 370 + 21.6 * 60 = 1666
+    assert!((bmr - 1666.0).abs() < 0.01);
+}
+
+#[test]
+fn tdee_sedentary() {
+    let lm = LeanMass::new(60.0).unwrap();
+    let result = tdee(lm, ActivityLevel::Sedentary);
+    // 1666 * 1.2 = 1999.2
+    assert!((result - 1999.2).abs() < 0.01);
+}
+
+#[test]
+fn tdee_very_active() {
+    let lm = LeanMass::new(60.0).unwrap();
+    let result = tdee(lm, ActivityLevel::VeryActive);
+    // 1666 * 1.725 = 2873.85
+    assert!((result - 2873.85).abs() < 0.01);
+}
+
+#[test]
+fn daily_target_with_deficit() {
+    let target = daily_target(2200.0, Weight::new(83.0).unwrap(), 500.0, 1.8);
+    assert!((target.as_ref().unwrap().kcal - 1700.0).abs() < 0.01);
+    assert!((target.as_ref().unwrap().protein_g - 149.4).abs() < 0.01);
+}
+
+#[test]
+fn daily_target_zero_deficit() {
+    let target = daily_target(2000.0, Weight::new(70.0).unwrap(), 0.0, 2.0);
+    assert!((target.as_ref().unwrap().kcal - 2000.0).abs() < 0.01);
+    assert!((target.as_ref().unwrap().protein_g - 140.0).abs() < 0.01);
+}
+
+#[test]
+fn daily_target_below_safe() {
+    let target = daily_target(2500.0, Weight::new(80.0).unwrap(), 1500.0, 2.0);
+    assert!(target.is_err());
+}

--- a/crates/domain/tests/test_measurement.rs
+++ b/crates/domain/tests/test_measurement.rs
@@ -1,0 +1,41 @@
+use chrono::Utc;
+use stadera_domain::measurement::Measurement;
+use stadera_domain::units::{BodyFatPercent, Height, LeanMass, Weight};
+
+fn sample_full() -> Measurement {
+    Measurement::new(
+        Utc::now(),
+        Weight::new(80.0).unwrap(),
+        Some(BodyFatPercent::new(20.0).unwrap()),
+        Some(LeanMass::new(64.0).unwrap()),
+    )
+}
+
+#[test]
+fn fat_mass_with_body_fat() {
+    let m = sample_full();
+    let fat = m.fat_mass().unwrap();
+    assert!((fat - 16.0).abs() < 0.01);
+}
+
+#[test]
+fn fat_mass_without_body_fat() {
+    let m = Measurement::new(Utc::now(), Weight::new(75.0).unwrap(), None, None);
+    assert!(m.fat_mass().is_none());
+}
+
+#[test]
+fn bmi_calculation() {
+    let m = Measurement::new(Utc::now(), Weight::new(70.0).unwrap(), None, None);
+    let bmi = m.bmi(Height::new(175.0).unwrap());
+    // 70 / (1.75^2) = 70 / 3.0625 ≈ 22.857
+    assert!((bmi - 22.857).abs() < 0.01);
+}
+
+#[test]
+fn bmi_short_person() {
+    let m = Measurement::new(Utc::now(), Weight::new(60.0).unwrap(), None, None);
+    let bmi = m.bmi(Height::new(150.0).unwrap());
+    // 60 / (1.5^2) = 60 / 2.25 ≈ 26.667
+    assert!((bmi - 26.667).abs() < 0.01);
+}

--- a/crates/domain/tests/test_trend.rs
+++ b/crates/domain/tests/test_trend.rs
@@ -1,0 +1,107 @@
+use chrono::{NaiveDate, TimeDelta, TimeZone, Utc};
+use stadera_domain::measurement::Measurement;
+use stadera_domain::trend::{compute_trend, estimate_goal_date};
+use stadera_domain::units::Weight;
+
+fn make_measurement(date: NaiveDate, weight_kg: f64) -> Measurement {
+    Measurement::new(
+        Utc.from_utc_datetime(&date.and_hms_opt(8, 0, 0).unwrap()),
+        Weight::new(weight_kg).unwrap(),
+        None,
+        None,
+    )
+}
+
+#[test]
+fn empty_measurements() {
+    let trend = compute_trend(&[]);
+    assert!(trend.moving_average_7d.is_none());
+    assert!(trend.weekly_delta_kg.is_none());
+}
+
+#[test]
+fn fewer_than_seven_days() {
+    let base = NaiveDate::from_ymd_opt(2024, 6, 10).unwrap();
+    let measurements = vec![
+        make_measurement(base, 80.0),
+        make_measurement(base + TimeDelta::days(1), 79.8),
+        make_measurement(base + TimeDelta::days(2), 79.6),
+    ];
+    let trend = compute_trend(&measurements);
+    assert!(trend.moving_average_7d.is_some());
+    assert!(trend.weekly_delta_kg.is_none());
+}
+
+#[test]
+fn exactly_seven_days() {
+    let base = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let measurements: Vec<Measurement> = (0..7)
+        .map(|i| make_measurement(base + TimeDelta::days(i), 80.0 - i as f64 * 0.2))
+        .collect();
+    let trend = compute_trend(&measurements);
+    assert!(trend.moving_average_7d.is_some());
+    assert!(trend.weekly_delta_kg.is_none());
+}
+
+#[test]
+fn fourteen_days_computes_delta() {
+    let base = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let measurements: Vec<Measurement> = (0..14)
+        .map(|i| make_measurement(base + TimeDelta::days(i), 80.0 - i as f64 * 0.1))
+        .collect();
+    let trend = compute_trend(&measurements);
+    assert!(trend.moving_average_7d.is_some());
+    assert!(trend.weekly_delta_kg.is_some());
+    assert!(trend.weekly_delta_kg.unwrap() < 0.0);
+}
+
+#[test]
+fn moving_average_value() {
+    let base = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let measurements = vec![
+        make_measurement(base, 80.0),
+        make_measurement(base + TimeDelta::days(1), 80.0),
+        make_measurement(base + TimeDelta::days(2), 80.0),
+    ];
+    let trend = compute_trend(&measurements);
+    let avg = trend.moving_average_7d.unwrap();
+    assert!((avg.value() - 80.0).abs() < 0.01);
+}
+
+// — estimate_goal_date —
+
+#[test]
+fn estimate_goal_losing_weight() {
+    let today = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let current = Weight::new(80.0).unwrap();
+    let goal = Weight::new(75.0).unwrap();
+    let result = estimate_goal_date(current, goal, -0.5, today);
+    assert!(result.is_some());
+    // 5 kg / 0.5 kg/week = 10 weeks = 70 days
+    let expected = today + TimeDelta::days(70);
+    assert_eq!(result.unwrap(), expected);
+}
+
+#[test]
+fn estimate_goal_wrong_direction() {
+    let today = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let current = Weight::new(80.0).unwrap();
+    let goal = Weight::new(75.0).unwrap();
+    // gaining weight but goal is lower → None
+    assert!(estimate_goal_date(current, goal, 0.5, today).is_none());
+}
+
+#[test]
+fn estimate_goal_already_at_target() {
+    let today = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let w = Weight::new(75.0).unwrap();
+    assert_eq!(estimate_goal_date(w, w, -0.5, today), Some(today));
+}
+
+#[test]
+fn estimate_goal_zero_delta() {
+    let today = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let current = Weight::new(80.0).unwrap();
+    let goal = Weight::new(75.0).unwrap();
+    assert!(estimate_goal_date(current, goal, 0.0, today).is_none());
+}

--- a/crates/domain/tests/test_units.rs
+++ b/crates/domain/tests/test_units.rs
@@ -43,6 +43,13 @@ fn weight_try_from() {
     assert!(w.is_ok());
 }
 
+#[test]
+fn weight_deserialize_rejects_invalid() {
+    assert!(serde_json::from_str::<Weight>("-10.0").is_err());
+    assert!(serde_json::from_str::<Weight>("600.0").is_err());
+    assert!(serde_json::from_str::<Weight>("null").is_err());
+}
+
 // — BodyFatPercent —
 
 #[test]
@@ -74,6 +81,13 @@ fn body_fat_display() {
     assert_eq!(BodyFatPercent::new(15.0).unwrap().to_string(), "15.0%");
 }
 
+#[test]
+fn body_fat_deserialize_rejects_invalid() {
+    assert!(serde_json::from_str::<BodyFatPercent>("-10.0").is_err());
+    assert!(serde_json::from_str::<BodyFatPercent>("600.0").is_err());
+    assert!(serde_json::from_str::<BodyFatPercent>("null").is_err());
+}
+
 // — LeanMass —
 
 #[test]
@@ -97,6 +111,13 @@ fn lean_mass_display() {
     assert_eq!(LeanMass::new(60.0).unwrap().to_string(), "60.0 kg");
 }
 
+#[test]
+fn lean_mass_deserialize_rejects_invalid() {
+    assert!(serde_json::from_str::<LeanMass>("-10.0").is_err());
+    assert!(serde_json::from_str::<LeanMass>("600.0").is_err());
+    assert!(serde_json::from_str::<LeanMass>("null").is_err());
+}
+
 // — Height —
 
 #[test]
@@ -118,6 +139,13 @@ fn height_rejects_above_limit() {
 #[test]
 fn height_display() {
     assert_eq!(Height::new(175.0).unwrap().to_string(), "175.0 cm");
+}
+
+#[test]
+fn height_deserialize_rejects_invalid() {
+    assert!(serde_json::from_str::<Height>("-10.0").is_err());
+    assert!(serde_json::from_str::<Height>("600.0").is_err());
+    assert!(serde_json::from_str::<Height>("null").is_err());
 }
 
 // — Property tests —

--- a/crates/domain/tests/test_units.rs
+++ b/crates/domain/tests/test_units.rs
@@ -1,0 +1,143 @@
+use proptest::prelude::*;
+use stadera_domain::error::DomainError;
+use stadera_domain::units::{BodyFatPercent, Height, LeanMass, Weight};
+
+// — Weight —
+
+#[test]
+fn weight_accepts_plausible_value() {
+    let w = Weight::new(75.3).unwrap();
+    assert!((w.value() - 75.3).abs() < f64::EPSILON);
+}
+
+#[test]
+fn weight_rejects_nan() {
+    assert_eq!(Weight::new(f64::NAN), Err(DomainError::NotFinite));
+}
+
+#[test]
+fn weight_rejects_negative() {
+    assert!(Weight::new(-5.0).is_err());
+}
+
+#[test]
+fn weight_rejects_above_limit() {
+    assert!(Weight::new(501.0).is_err());
+}
+
+#[test]
+fn weight_boundary_values() {
+    assert!(Weight::new(10.0).is_ok());
+    assert!(Weight::new(500.0).is_ok());
+    assert!(Weight::new(9.9).is_err());
+}
+
+#[test]
+fn weight_display() {
+    assert_eq!(Weight::new(75.3).unwrap().to_string(), "75.3 kg");
+}
+
+#[test]
+fn weight_try_from() {
+    let w: Result<Weight, _> = 80.0_f64.try_into();
+    assert!(w.is_ok());
+}
+
+// — BodyFatPercent —
+
+#[test]
+fn body_fat_accepts_plausible_value() {
+    let bf = BodyFatPercent::new(15.0).unwrap();
+    assert!((bf.value() - 15.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn body_fat_rejects_below_minimum() {
+    assert!(BodyFatPercent::new(1.0).is_err());
+}
+
+#[test]
+fn body_fat_rejects_above_limit() {
+    assert!(BodyFatPercent::new(81.0).is_err());
+}
+
+#[test]
+fn body_fat_rejects_infinity() {
+    assert_eq!(
+        BodyFatPercent::new(f64::INFINITY),
+        Err(DomainError::NotFinite)
+    );
+}
+
+#[test]
+fn body_fat_display() {
+    assert_eq!(BodyFatPercent::new(15.0).unwrap().to_string(), "15.0%");
+}
+
+// — LeanMass —
+
+#[test]
+fn lean_mass_accepts_plausible_value() {
+    let lm = LeanMass::new(60.0).unwrap();
+    assert!((lm.value() - 60.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn lean_mass_rejects_nan() {
+    assert_eq!(LeanMass::new(f64::NAN), Err(DomainError::NotFinite));
+}
+
+#[test]
+fn lean_mass_rejects_below_minimum() {
+    assert!(LeanMass::new(1.0).is_err());
+}
+
+#[test]
+fn lean_mass_display() {
+    assert_eq!(LeanMass::new(60.0).unwrap().to_string(), "60.0 kg");
+}
+
+// — Height —
+
+#[test]
+fn height_accepts_plausible_value() {
+    let h = Height::new(175.0).unwrap();
+    assert!((h.value() - 175.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn height_rejects_below_minimum() {
+    assert!(Height::new(30.0).is_err());
+}
+
+#[test]
+fn height_rejects_above_limit() {
+    assert!(Height::new(301.0).is_err());
+}
+
+#[test]
+fn height_display() {
+    assert_eq!(Height::new(175.0).unwrap().to_string(), "175.0 cm");
+}
+
+// — Property tests —
+
+proptest! {
+    #[test]
+    fn weight_roundtrip(v in 10.0f64..=500.0) {
+        let w = Weight::new(v).unwrap();
+        prop_assert!((w.value() - v).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn body_fat_roundtrip(v in 2.0f64..=80.0) {
+        let bf = BodyFatPercent::new(v).unwrap();
+        prop_assert!((bf.value() - v).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn height_roundtrip(v in 50.0f64..=300.0) {
+        let h = Height::new(v).unwrap();
+        prop_assert!((h.value() - v).abs() < f64::EPSILON);
+    }
+}

--- a/crates/domain/tests/test_user.rs
+++ b/crates/domain/tests/test_user.rs
@@ -1,0 +1,42 @@
+use chrono::NaiveDate;
+use stadera_domain::units::{Height, Weight};
+use stadera_domain::user::{ActivityLevel, Sex, UserProfile};
+
+fn sample_profile() -> UserProfile {
+    UserProfile {
+        birth_date: NaiveDate::from_ymd_opt(1990, 6, 15).unwrap(),
+        sex: Sex::Male,
+        height: Height::new(175.0).unwrap(),
+        activity: ActivityLevel::ModeratelyActive,
+        goal_weight: Weight::new(75.0).unwrap(),
+    }
+}
+
+#[test]
+fn age_on_birthday() {
+    let p = sample_profile();
+    let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+    assert_eq!(p.age(today), 34);
+}
+
+#[test]
+fn age_before_birthday_this_year() {
+    let p = sample_profile();
+    let today = NaiveDate::from_ymd_opt(2024, 3, 1).unwrap();
+    assert_eq!(p.age(today), 33);
+}
+
+#[test]
+fn age_after_birthday_this_year() {
+    let p = sample_profile();
+    let today = NaiveDate::from_ymd_opt(2024, 12, 1).unwrap();
+    assert_eq!(p.age(today), 34);
+}
+
+#[test]
+fn activity_multipliers() {
+    assert!((ActivityLevel::Sedentary.multiplier() - 1.2).abs() < f64::EPSILON);
+    assert!((ActivityLevel::LightlyActive.multiplier() - 1.375).abs() < f64::EPSILON);
+    assert!((ActivityLevel::ModeratelyActive.multiplier() - 1.55).abs() < f64::EPSILON);
+    assert!((ActivityLevel::VeryActive.multiplier() - 1.725).abs() < f64::EPSILON);
+}


### PR DESCRIPTION

## Summary

Introduce the `stadera-domain` crate — the core business logic layer for Stadera. Pure functions, strongly-typed values, zero I/O.

## What changed

### New crate: domain

| Module | Description |
|---|---|
| **`units`** | Newtype wrappers (`Weight`, `BodyFatPercent`, `LeanMass`, `Height`) with validated constructors, `TryFrom<f64>`, `Display` |
| **`error`** | `DomainError` enum with contextual error messages (includes the rejected value) |
| **`measurement`** | `Measurement` aggregate — `fat_mass()` and `bmi(height)` |
| **`user`** | `Sex`, `ActivityLevel` (with multipliers), `UserProfile` with injectable `age(today)` |
| **`energy`** | Katch-McArdle BMR, TDEE calculation, `DailyTarget` with deficit/protein |
| **`trend`** | `WeightTrend` (7-day moving average + weekly delta), `estimate_goal_date` projection |

### Workspace changes
- Centralized `serde` and `chrono` in `[workspace.dependencies]`
- Domain crate uses `thiserror`, `serde`, `chrono` from workspace; `proptest` as dev-dep

## Design decisions

- **No raw `f64` in the domain** — all physical quantities are newtypes with validation
- **No `unwrap()` / `panic!()` in non-test code**
- **No `Utc::now()` inside domain** — time is always injected for testability
- **`LeanMass` as independent type** (Withings measures it via impedance, not derived arithmetically)
- **Tests in dedicated files** under `tests/` rather than inline `#[cfg(test)]` modules

## Test coverage

45 tests across 5 files, including property-based tests with `proptest`:

| File | Tests |
|---|---|
| test_units.rs | 23 (incl. 3 proptest roundtrips) |
| `test_trend.rs` | 9 |
| test_energy.rs | 5 |
| test_measurement.rs | 4 |
| `test_user.rs` | 4 |

`cargo clippy --all-targets -- -D warnings` ✅