### PR TITLE
Feat/storage scaffold

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -70,8 +70,8 @@ stadera/
 | ID | Name | Status | Notes |
 |---|---|---|---|
 | M1 | Foundations | ✅ Done | Workspace, CI, release-please, conventional commits |
-| M2 | Domain core | ⏳ In review | PR #2 open. 3 blockers to fix — see `reviews/pr-2.md` |
-| M3 | Storage | ⏸ Next | Postgres schema, sqlx migrations, repository pattern, Docker compose for local dev |
+| M2 | Domain core | ✅ Done | Merged via PR #2 (squashed into `1507c18`). Domain blockers resolved. Follow-ups tracked in `reviews/pr-2.md` |
+| M3 | Storage | ⏳ In progress | Split into 2 PRs: `feat/storage-scaffold` (schema+compose+migrations) then `feat/storage-repositories` (repo pattern + tests) |
 | M4 | Withings integration | 📋 Planned | OAuth2 flow, token refresh, API client, sync binary. Multi-tenant DB schema ready |
 | M5 | API + Frontend | 📋 Planned | axum endpoints (`/today`, `/trend`, `/history`), OAuth Google auth middleware, utoipa/Swagger. `stadera-web` repo scaffolded |
 | M6 | Notifications | 📋 Planned | Pushover daily job, Resend weekly digest (Apple-weekly-summary style) |
@@ -92,13 +92,18 @@ stadera/
 - All domain values are newtypes with validating constructors. No raw `f64`/`i64` at the domain boundary.
 - Tests in `tests/` dir (integration-test style) instead of inline `#[cfg(test)]` — forces testing through the public API.
 
-### Storage layer (M3 decisions pending)
+### Storage layer (M3) — resolved
 
-Open questions to resolve when starting M3:
-- Repository pattern via traits (for testability) vs. direct `sqlx` calls in services?
-- Migration strategy: `sqlx migrate` CLI vs. a lib-level migration runner at startup?
-- Connection pooling config — `sqlx::PgPool` defaults or custom sizing for Cloud Run (scale-to-zero → cold starts)?
-- Docker compose for local Postgres 16? (probably yes)
+- **Repository pattern**: concrete structs (`PgMeasurementRepository`, …), no traits for now. Integration tests against a real DB. Traits only when a mock actually becomes necessary.
+- **Migrations lifecycle**: `sqlx migrate` CLI for local dev + `sqlx::migrate!().run(&pool)` inside the binary on startup (Cloud Run self-migrates on cold start). Same `migrations/` directory feeds both.
+- **Connection pool**: `max_connections = 10`, `connect_timeout = 5s`. Tuned finer in M7 when observing actual load on Cloud Run + Neon pooler.
+- **Dev env**: `compose.yaml` with Postgres 16, root-level `Makefile` for `db-up` / `db-down` / `db-migrate` / `db-reset` / `db-psql`.
+- **Schema**: UUID v7 for PKs (time-ordered, cloud-native), `timestamptz` for all temporal columns, `varchar + CHECK` for enums (easier to evolve than native Postgres enum).
+- **Tables in M3**: `users`, `user_profiles`, `measurements`, `withings_credentials`. The last one is pre-provisioned even though its usage lands in M4 — avoids an extra migration PR.
+- **Domain ↔ SQL mapping**: repository performs `Weight::try_from(f64)?` on read; returns `StorageError::Corruption` if the DB produced an invalid value (should not happen, but explicit).
+- **`Measurement::source`** (`Withings` | `Manual`): extended in the domain now to avoid a second-wave domain bump in M4.
+- **Withings token encryption**: column `BYTEA` in M3; encryption logic lands in M4 together with the OAuth flow (key from Secret Manager).
+- **Integration tests**: `sqlx::test` macro (lighter than testcontainers). Requires a reachable `DATABASE_URL` in CI — add a `postgres` service to `ci.yml`.
 
 ### Notifications (M6 decisions pending)
 
@@ -106,11 +111,12 @@ Open questions to resolve when starting M3:
 - Weekly digest email: Sunday evening or Monday morning?
 - Email template: HTML with MJML, or plain-ish styled?
 
-### Cloud (M7 decisions pending)
+### Cloud (M7 — partially resolved)
 
-- Single GCP project or separate for Stadera?
-- Custom domain from day 1 or `.run.app` URL?
-- Staging/preview envs on Vercel previews only, backend always single-env?
+- **GCP project**: `stadera-prod` (single project, single env — matches the single-env decision).
+- **Neon layout**: 1 project `stadera`, default `main` branch (Neon's copy-on-write branches), database `stadera`, dedicated role `stadera_app` (least privilege, not the `neondb_owner`). Neon branching available for preview envs in the future, out-of-scope for now.
+- **Custom domain** vs `.run.app`: still open. Decide in M7.
+- **Preview envs**: Vercel previews on frontend PRs; backend stays single-env (feature branches test locally against Docker).
 
 ## Conventions (quick reference)
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+
+.env
+.env.local
+
+DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .env
 .env.local
 
-DS_Store
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "storage"
+name = "stadera-storage"
 version = "0.1.0"
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "storage"
+version = "0.1.0"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ sqlx = { version = "0.8", default-features = false, features = [
     "migrate",
 ] }
 uuid = { version = "1", features = ["v7", "serde"] }
+serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/api", "crates/domain"]
+members = ["crates/api", "crates/domain", "crates/storage"]
 
 [workspace.package]
 edition = "2024"
@@ -15,3 +15,14 @@ serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# database
+sqlx = { version = "0.8", default-features = false, features = [
+    "postgres",
+    "runtime-tokio",
+    "tls-rustls",
+    "chrono",
+    "uuid",
+    "macros",
+    "migrate",
+] }
+uuid = { version = "1", features = ["v7", "serde"] }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help db-up db-down db-reset db-migrate db-psql check
+
+help:
+	@echo "Dev targets:"
+	@echo "  db-up        Start Postgres (Docker Compose)"
+	@echo "  db-down      Stop Postgres"
+	@echo "  db-reset     Destroy volume and recreate + migrate"
+	@echo "  db-migrate   Run sqlx migrations against local DB"
+	@echo "  db-psql      Open psql shell into local DB"
+	@echo "  check        cargo fmt + clippy + test"
+
+db-up:
+	docker compose up -d postgres
+	@echo "Waiting for Postgres to be ready..."
+	@until docker compose exec -T postgres pg_isready -U stadera -d stadera > /dev/null 2>&1; do sleep 1; done
+	@echo "Postgres ready at postgres://stadera:stadera@localhost:5432/stadera"
+
+db-down:
+	docker compose down
+
+db-reset:
+	docker compose down -v
+	$(MAKE) db-up
+	$(MAKE) db-migrate
+
+db-migrate:
+	cd crates/storage && sqlx migrate run
+
+db-psql:
+	docker compose exec postgres psql -U stadera -d stadera
+
+check:
+	cargo fmt --all -- --check
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo test --all

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: stadera-postgres
+    environment:
+      POSTGRES_USER: stadera
+      POSTGRES_PASSWORD: stadera
+      POSTGRES_DB: stadera
+    ports:
+      - "5432:5432"
+    volumes:
+      - stadera-pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U stadera -d stadera"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  stadera-pg-data:

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -11,7 +11,7 @@ pub mod user;
 
 pub use energy::DailyTarget;
 pub use error::DomainError;
-pub use measurement::Measurement;
+pub use measurement::{ Measurement, Source };
 pub use trend::WeightTrend;
 pub use units::{BodyFatPercent, Height, LeanMass, Weight};
 pub use user::{ActivityLevel, Sex, UserProfile};

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -11,7 +11,7 @@ pub mod user;
 
 pub use energy::DailyTarget;
 pub use error::DomainError;
-pub use measurement::{ Measurement, Source };
+pub use measurement::{Measurement, Source};
 pub use trend::WeightTrend;
 pub use units::{BodyFatPercent, Height, LeanMass, Weight};
 pub use user::{ActivityLevel, Sex, UserProfile};

--- a/crates/domain/src/measurement.rs
+++ b/crates/domain/src/measurement.rs
@@ -5,7 +5,7 @@ use crate::units::{BodyFatPercent, Height, LeanMass, Weight};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Source{
+pub enum Source {
     Withings,
     Manual,
 }
@@ -32,7 +32,6 @@ impl Measurement {
             body_fat,
             lean_mass,
             source,
-
         }
     }
 

--- a/crates/domain/src/measurement.rs
+++ b/crates/domain/src/measurement.rs
@@ -4,11 +4,18 @@ use serde::{Deserialize, Serialize};
 use crate::units::{BodyFatPercent, Height, LeanMass, Weight};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Source{
+    Withings,
+    Manual,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Measurement {
     pub taken_at: DateTime<Utc>,
     pub weight: Weight,
     pub body_fat: Option<BodyFatPercent>,
     pub lean_mass: Option<LeanMass>,
+    pub source: Source,
 }
 
 impl Measurement {
@@ -17,12 +24,15 @@ impl Measurement {
         weight: Weight,
         body_fat: Option<BodyFatPercent>,
         lean_mass: Option<LeanMass>,
+        source: Source,
     ) -> Self {
         Self {
             taken_at,
             weight,
             body_fat,
             lean_mass,
+            source,
+
         }
     }
 

--- a/crates/domain/tests/test_measurement.rs
+++ b/crates/domain/tests/test_measurement.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use stadera_domain::measurement::Measurement;
+use stadera_domain::measurement::{Measurement, Source};
 use stadera_domain::units::{BodyFatPercent, Height, LeanMass, Weight};
 
 fn sample_full() -> Measurement {
@@ -8,6 +8,7 @@ fn sample_full() -> Measurement {
         Weight::new(80.0).unwrap(),
         Some(BodyFatPercent::new(20.0).unwrap()),
         Some(LeanMass::new(64.0).unwrap()),
+        Source::Withings,
     )
 }
 
@@ -20,13 +21,25 @@ fn fat_mass_with_body_fat() {
 
 #[test]
 fn fat_mass_without_body_fat() {
-    let m = Measurement::new(Utc::now(), Weight::new(75.0).unwrap(), None, None);
+    let m = Measurement::new(
+        Utc::now(),
+        Weight::new(75.0).unwrap(),
+        None,
+        None,
+        Source::Manual,
+    );
     assert!(m.fat_mass().is_none());
 }
 
 #[test]
 fn bmi_calculation() {
-    let m = Measurement::new(Utc::now(), Weight::new(70.0).unwrap(), None, None);
+    let m = Measurement::new(
+        Utc::now(),
+        Weight::new(70.0).unwrap(),
+        None,
+        None,
+        Source::Withings,
+    );
     let bmi = m.bmi(Height::new(175.0).unwrap());
     // 70 / (1.75^2) = 70 / 3.0625 ≈ 22.857
     assert!((bmi - 22.857).abs() < 0.01);
@@ -34,8 +47,26 @@ fn bmi_calculation() {
 
 #[test]
 fn bmi_short_person() {
-    let m = Measurement::new(Utc::now(), Weight::new(60.0).unwrap(), None, None);
+    let m = Measurement::new(
+        Utc::now(),
+        Weight::new(60.0).unwrap(),
+        None,
+        None,
+        Source::Manual,
+    );
     let bmi = m.bmi(Height::new(150.0).unwrap());
     // 60 / (1.5^2) = 60 / 2.25 ≈ 26.667
     assert!((bmi - 26.667).abs() < 0.01);
+}
+
+#[test]
+fn source_serde_snake_case() {
+    let json = serde_json::to_string(&Source::Withings).unwrap();
+    assert_eq!(json, "\"withings\"");
+
+    let json = serde_json::to_string(&Source::Manual).unwrap();
+    assert_eq!(json, "\"manual\"");
+
+    let deserialized: Source = serde_json::from_str("\"withings\"").unwrap();
+    assert_eq!(deserialized, Source::Withings);
 }

--- a/crates/domain/tests/test_trend.rs
+++ b/crates/domain/tests/test_trend.rs
@@ -1,5 +1,5 @@
 use chrono::{NaiveDate, TimeDelta, TimeZone, Utc};
-use stadera_domain::measurement::Measurement;
+use stadera_domain::measurement::{Measurement, Source};
 use stadera_domain::trend::{compute_trend, estimate_goal_date};
 use stadera_domain::units::Weight;
 
@@ -9,6 +9,7 @@ fn make_measurement(date: NaiveDate, weight_kg: f64) -> Measurement {
         Weight::new(weight_kg).unwrap(),
         None,
         None,
+        Source::Withings,
     )
 }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "storage"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storage"
+name = "stadera-storage"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true

--- a/crates/storage/README.md
+++ b/crates/storage/README.md
@@ -1,0 +1,18 @@
+# stadera-storage
+
+Postgres persistence layer. Repositories for the domain aggregates.
+
+## Local dev setup
+
+Prerequisites:
+
+- Docker (Compose v2)
+- `sqlx-cli`: `cargo install sqlx-cli --no-default-features --features postgres,rustls`
+
+Bring up Postgres and apply migrations:
+
+```bash
+cp .env.example .env  # adjust if needed
+make db-up
+make db-migrate
+```

--- a/crates/storage/migrations/20260424192350_init.sql
+++ b/crates/storage/migrations/20260424192350_init.sql
@@ -1,0 +1,43 @@
+-- Add migration script here
+-- Initial schema: users, user_profiles, measurements, withings_credentials.
+-- Multi-tenant-ready from day 1 (every table has user_id).
+
+CREATE TABLE users (
+    id         UUID PRIMARY KEY,
+    email      VARCHAR(320) NOT NULL UNIQUE,
+    name       VARCHAR(200) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_profiles (
+    user_id        UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    sex            VARCHAR(10) NOT NULL CHECK (sex IN ('male', 'female')),
+    birth_date     DATE NOT NULL,
+    height_cm      DOUBLE PRECISION NOT NULL CHECK (height_cm BETWEEN 50 AND 300),
+    activity_level VARCHAR(20) NOT NULL CHECK (activity_level IN ('sedentary', 'lightly_active', 'moderately_active', 'very_active')),
+    goal_weight_kg DOUBLE PRECISION NOT NULL CHECK (goal_weight_kg BETWEEN 10 AND 500),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE measurements (
+    id               UUID PRIMARY KEY,
+    user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    taken_at         TIMESTAMPTZ NOT NULL,
+    weight_kg        DOUBLE PRECISION NOT NULL CHECK (weight_kg BETWEEN 10 AND 500),
+    body_fat_percent DOUBLE PRECISION CHECK (body_fat_percent BETWEEN 2 AND 80),
+    lean_mass_kg     DOUBLE PRECISION CHECK (lean_mass_kg BETWEEN 2 AND 300),
+    source           VARCHAR(20) NOT NULL CHECK (source IN ('withings', 'manual')),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX measurements_user_taken_at_idx ON measurements (user_id, taken_at DESC);
+
+CREATE TABLE withings_credentials (
+    user_id           UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    access_token_enc  BYTEA NOT NULL,
+    refresh_token_enc BYTEA NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    scope             VARCHAR(500) NOT NULL,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,11 @@
 {
+"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "separate-pull-requests": false,
+  "include-component-in-tag": true,
   "packages": {
-    "crates/api": {
-      "release-type": "rust",
-      "package-name": "stadera-api",
-      "include-component-in-tag": false,
-      "bump-minor-pre-major": true,
-      "draft": false,
-      "prerelease": false
-    }
-  },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+    "crates/api":     { "package-name": "stadera-api",     "component": "api"     },
+    "crates/domain":  { "package-name": "stadera-domain",  "component": "domain"  },
+    "crates/storage": { "package-name": "stadera-storage", "component": "storage" }
+  }
 }

--- a/release-please-manifest.json
+++ b/release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  "crates/api": "0.1.0"
+  "crates/api":     "0.1.0",
+  "crates/domain":  "0.1.0",
+  "crates/storage": "0.1.0"
 }


### PR DESCRIPTION
## Summary
Scaffold the `stadera-storage` crate: initial Postgres schema, sqlx migrations,
local Docker Compose dev env, release-please tracking. Extends `stadera-domain`
with a `Source` enum required by the schema.

## Motivation
- Milestone: M3 (first of 2 PRs)
- This PR: data model + dev env. Next PR: repository pattern + integration tests.

## Changes
- `crates/storage` scaffold (Cargo.toml, lib.rs, README)
- Migration `20260424192350_init.sql`: users, user_profiles, measurements, 
  withings_credentials. UUID v7 PKs, timestamptz, varchar+CHECK enums, index on
  measurements(user_id, taken_at DESC), ON DELETE CASCADE.
- Domain: `Source` enum (Withings | Manual) added to Measurement — required by
  schema, landed here to avoid a domain bump in M4.
- Dev env: compose.yaml (Postgres 16 alpine + healthcheck), root Makefile 
  (db-up/down/reset/migrate/psql/check).
- Workspace deps: sqlx 0.8, uuid 1, serde_json 1.
- release-please: tracking domain + storage (closes C7 gap from PR #2 review).

## Test plan
- [x] cargo fmt / clippy -D warnings / test --all (all green locally)
- [x] make db-up + make db-migrate applies schema clean

## Notes for reviewer
- Migration is forward-only (no .up/.down split) — simpler for M3.
- CHECK constraints duplicate newtype validation: defense-in-depth.
- Withings token columns pre-provisioned (BYTEA); encryption in M4.