### PR TITLE
feat(storage): implement repository layer with integration tests

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -71,7 +71,7 @@ stadera/
 |---|---|---|---|
 | M1 | Foundations | ✅ Done | Workspace, CI, release-please, conventional commits |
 | M2 | Domain core | ✅ Done | Merged via PR #2 (squashed into `1507c18`). Domain blockers resolved. Follow-ups tracked in `reviews/pr-2.md` |
-| M3 | Storage | ⏳ In progress | Split into 2 PRs: `feat/storage-scaffold` (schema+compose+migrations) then `feat/storage-repositories` (repo pattern + tests) |
+| M3 | Storage | ⏳ In progress | PR A `feat/storage-scaffold` merged (#3). PR B `feat/storage-repositories` open: repositories + integration tests + CI Postgres service |
 | M4 | Withings integration | 📋 Planned | OAuth2 flow, token refresh, API client, sync binary. Multi-tenant DB schema ready |
 | M5 | API + Frontend | 📋 Planned | axum endpoints (`/today`, `/trend`, `/history`), OAuth Google auth middleware, utoipa/Swagger. `stadera-web` repo scaffolded |
 | M6 | Notifications | 📋 Planned | Pushover daily job, Resend weekly digest (Apple-weekly-summary style) |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  DATABASE_URL: postgres://stadera:stadera@localhost:5432/stadera
 
 jobs:
   fmt:
@@ -34,6 +35,20 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: stadera
+          POSTGRES_PASSWORD: stadera
+          POSTGRES_DB: stadera
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -45,12 +60,32 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install sqlx-cli
+        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+
+      - name: Run migrations
+        run: sqlx migrate run --source crates/storage/migrations
+
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: stadera
+          POSTGRES_PASSWORD: stadera
+          POSTGRES_DB: stadera
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -59,6 +94,12 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+
+      - name: Install sqlx-cli
+        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+
+      - name: Run migrations
+        run: sqlx migrate run --source crates/storage/migrations
 
       - name: Run tests
         run: cargo test --all --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +33,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -52,12 +79,30 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -96,10 +141,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -114,7 +272,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -130,6 +310,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +331,107 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -172,6 +464,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -182,10 +476,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -212,10 +548,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -250,6 +689,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -264,10 +706,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -294,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,7 +793,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -316,7 +802,43 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -326,6 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -333,6 +856,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -352,16 +881,73 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -401,8 +987,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -439,12 +1025,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -454,7 +1061,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -472,7 +1088,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -480,6 +1096,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -502,6 +1127,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +1170,41 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -531,6 +1224,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -588,6 +1287,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,10 +1346,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -625,8 +1377,231 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stadera-api"
@@ -652,6 +1627,33 @@ dependencies = [
 [[package]]
 name = "stadera-storage"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "sqlx",
+ "stadera-domain",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -665,6 +1667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +1687,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -707,6 +1720,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,7 +1758,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -735,11 +1773,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -796,10 +1846,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -808,16 +1870,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -851,6 +1976,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -932,6 +2063,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,12 +2151,151 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1094,6 +2392,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +2434,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -6,3 +6,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+stadera-domain = { path = "../domain" }
+sqlx.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+pub type StorageResult<T> = Result<T, StorageError>;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("data corruption in {table}: {msg}")]
+    Corruption { table: &'static str, msg: String },
+}
+
+impl StorageError {
+    pub(crate) fn corruption(table: &'static str, msg: impl Into<String>) -> Self {
+        Self::Corruption {
+            table,
+            msg: msg.into(),
+        }
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -8,6 +8,8 @@ pub mod repositories;
 mod rows;
 
 pub use error::{StorageError, StorageResult};
+pub use repositories::user::User;
+pub use repositories::withings_credentials::WithingsCredentials;
 
 use sqlx::PgPool;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,14 +1,40 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! Stadera storage layer: Postgres repositories for the domain types.
+//!
+//! Boundary between pure domain (`stadera-domain`) and the database.
+//! All I/O lives here.
+
+pub mod error;
+pub mod repositories;
+mod rows;
+
+pub use error::{StorageError, StorageResult};
+
+use sqlx::PgPool;
+
+use repositories::{
+    measurement::PgMeasurementRepository, user::PgUserRepository,
+    user_profile::PgUserProfileRepository, withings_credentials::PgWithingsCredentialsRepository,
+};
+
+pub struct StorageContext {
+    pool: PgPool,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl StorageContext {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    pub fn measurements(&self) -> PgMeasurementRepository<'_> {
+        PgMeasurementRepository::new(&self.pool)
+    }
+    pub fn users(&self) -> PgUserRepository<'_> {
+        PgUserRepository::new(&self.pool)
+    }
+    pub fn user_profiles(&self) -> PgUserProfileRepository<'_> {
+        PgUserProfileRepository::new(&self.pool)
+    }
+    pub fn withings_credentials(&self) -> PgWithingsCredentialsRepository<'_> {
+        PgWithingsCredentialsRepository::new(&self.pool)
     }
 }

--- a/crates/storage/src/repositories/measurement.rs
+++ b/crates/storage/src/repositories/measurement.rs
@@ -38,16 +38,40 @@ impl<'a> PgMeasurementRepository<'a> {
         Ok(id)
     }
 
+    /// Atomic batch insert: all measurements succeed or none are persisted.
+    /// Wraps the loop in a transaction so a mid-batch failure rolls back
+    /// every prior insert in the same call — safe to retry the full batch
+    /// without creating duplicates (new UUIDs would otherwise be generated
+    /// for already-inserted rows).
     #[instrument(skip(self, measurements))]
     pub async fn insert_batch(
         &self,
         user_id: Uuid,
         measurements: &[Measurement],
     ) -> StorageResult<Vec<Uuid>> {
+        let mut tx = self.pool.begin().await?;
         let mut ids = Vec::with_capacity(measurements.len());
         for m in measurements {
-            ids.push(self.insert(user_id, m).await?);
+            let id = Uuid::now_v7();
+            sqlx::query!(
+                r#"
+                INSERT INTO measurements
+                    (id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                "#,
+                id,
+                user_id,
+                m.taken_at,
+                m.weight.value(),
+                m.body_fat.map(|bf| bf.value()),
+                m.lean_mass.map(|lm| lm.value()),
+                source_to_str(m.source),
+            )
+            .execute(&mut *tx)
+            .await?;
+            ids.push(id);
         }
+        tx.commit().await?;
         Ok(ids)
     }
 

--- a/crates/storage/src/repositories/measurement.rs
+++ b/crates/storage/src/repositories/measurement.rs
@@ -1,0 +1,131 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use stadera_domain::Measurement;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::StorageResult;
+use crate::rows::{MeasurementRow, source_to_str};
+
+pub struct PgMeasurementRepository<'a> {
+    pool: &'a PgPool,
+}
+
+impl<'a> PgMeasurementRepository<'a> {
+    pub(crate) fn new(pool: &'a PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[instrument(skip(self, m))]
+    pub async fn insert(&self, user_id: Uuid, m: &Measurement) -> StorageResult<Uuid> {
+        let id = Uuid::now_v7();
+        sqlx::query!(
+            r#"
+            INSERT INTO measurements
+                (id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+            id,
+            user_id,
+            m.taken_at,
+            m.weight.value(),
+            m.body_fat.map(|bf| bf.value()),
+            m.lean_mass.map(|lm| lm.value()),
+            source_to_str(m.source),
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    #[instrument(skip(self, measurements))]
+    pub async fn insert_batch(
+        &self,
+        user_id: Uuid,
+        measurements: &[Measurement],
+    ) -> StorageResult<Vec<Uuid>> {
+        let mut ids = Vec::with_capacity(measurements.len());
+        for m in measurements {
+            ids.push(self.insert(user_id, m).await?);
+        }
+        Ok(ids)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_by_id(&self, id: Uuid) -> StorageResult<Option<Measurement>> {
+        let row = sqlx::query_as!(
+            MeasurementRow,
+            r#"
+            SELECT id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source, created_at
+            FROM measurements
+            WHERE id = $1
+            "#,
+            id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        row.map(Measurement::try_from).transpose()
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_for_user_between(
+        &self,
+        user_id: Uuid,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> StorageResult<Vec<Measurement>> {
+        let rows = sqlx::query_as!(
+            MeasurementRow,
+            r#"
+            SELECT id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source, created_at
+            FROM measurements
+            WHERE user_id = $1 AND taken_at >= $2 AND taken_at < $3
+            ORDER BY taken_at ASC
+            "#,
+            user_id, from, to
+        )
+        .fetch_all(self.pool)
+        .await?;
+        rows.into_iter().map(Measurement::try_from).collect()
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_for_user_latest(
+        &self,
+        user_id: Uuid,
+        limit: i64,
+    ) -> StorageResult<Vec<Measurement>> {
+        let rows = sqlx::query_as!(
+            MeasurementRow,
+            r#"
+            SELECT id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source, created_at
+            FROM measurements
+            WHERE user_id = $1
+            ORDER BY taken_at DESC
+            LIMIT $2
+            "#,
+            user_id, limit
+        )
+        .fetch_all(self.pool)
+        .await?;
+        rows.into_iter().map(Measurement::try_from).collect()
+    }
+
+    #[instrument(skip(self))]
+    pub async fn latest_for_user(&self, user_id: Uuid) -> StorageResult<Option<Measurement>> {
+        let row = sqlx::query_as!(
+            MeasurementRow,
+            r#"
+            SELECT id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source, created_at
+            FROM measurements
+            WHERE user_id = $1
+            ORDER BY taken_at DESC
+            LIMIT 1
+            "#,
+            user_id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        row.map(Measurement::try_from).transpose()
+    }
+}

--- a/crates/storage/src/repositories/mod.rs
+++ b/crates/storage/src/repositories/mod.rs
@@ -1,0 +1,4 @@
+pub mod measurement;
+pub mod user;
+pub mod user_profile;
+pub mod withings_credentials;

--- a/crates/storage/src/repositories/user.rs
+++ b/crates/storage/src/repositories/user.rs
@@ -1,0 +1,74 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::StorageResult;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct User {
+    pub id: Uuid,
+    pub email: String,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct PgUserRepository<'a> {
+    pool: &'a PgPool,
+}
+
+impl<'a> PgUserRepository<'a> {
+    pub(crate) fn new(pool: &'a PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[instrument(skip(self))]
+    pub async fn create(&self, email: &str, name: &str) -> StorageResult<Uuid> {
+        let id = Uuid::now_v7();
+        sqlx::query!(
+            r#"
+            INSERT INTO users (id, email, name)
+            VALUES ($1, $2, $3)
+            "#,
+            id,
+            email,
+            name,
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(id)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_by_id(&self, id: Uuid) -> StorageResult<Option<User>> {
+        let row = sqlx::query_as!(
+            User,
+            r#"
+            SELECT id, email, name, created_at, updated_at
+            FROM users
+            WHERE id = $1
+            "#,
+            id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_by_email(&self, email: &str) -> StorageResult<Option<User>> {
+        let row = sqlx::query_as!(
+            User,
+            r#"
+            SELECT id, email, name, created_at, updated_at
+            FROM users
+            WHERE email = $1
+            "#,
+            email
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(row)
+    }
+}

--- a/crates/storage/src/repositories/user_profile.rs
+++ b/crates/storage/src/repositories/user_profile.rs
@@ -1,0 +1,62 @@
+use chrono::Utc;
+use sqlx::PgPool;
+use stadera_domain::UserProfile;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::StorageResult;
+use crate::rows::{UserProfilesRow, activity_level_to_str, sex_to_str};
+
+pub struct PgUserProfileRepository<'a> {
+    pool: &'a PgPool,
+}
+
+impl<'a> PgUserProfileRepository<'a> {
+    pub(crate) fn new(pool: &'a PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[instrument(skip(self, profile))]
+    pub async fn upsert(&self, user_id: Uuid, profile: &UserProfile) -> StorageResult<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO user_profiles
+                (user_id, sex, birth_date, height_cm, activity_level, goal_weight_kg, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (user_id) DO UPDATE SET
+                sex            = EXCLUDED.sex,
+                birth_date     = EXCLUDED.birth_date,
+                height_cm      = EXCLUDED.height_cm,
+                activity_level = EXCLUDED.activity_level,
+                goal_weight_kg = EXCLUDED.goal_weight_kg,
+                updated_at     = EXCLUDED.updated_at
+            "#,
+            user_id,
+            sex_to_str(profile.sex),
+            profile.birth_date,
+            profile.height.value(),
+            activity_level_to_str(profile.activity),
+            profile.goal_weight.value(),
+            Utc::now(),
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_for_user(&self, user_id: Uuid) -> StorageResult<Option<UserProfile>> {
+        let row = sqlx::query_as!(
+            UserProfilesRow,
+            r#"
+            SELECT user_id, sex, birth_date, height_cm, activity_level, goal_weight_kg, updated_at
+            FROM user_profiles
+            WHERE user_id = $1
+            "#,
+            user_id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        row.map(UserProfile::try_from).transpose()
+    }
+}

--- a/crates/storage/src/repositories/withings_credentials.rs
+++ b/crates/storage/src/repositories/withings_credentials.rs
@@ -1,0 +1,82 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::StorageResult;
+
+#[derive(Clone)]
+pub struct WithingsCredentials {
+    pub user_id: Uuid,
+    pub access_token_enc: Vec<u8>,
+    pub refresh_token_enc: Vec<u8>,
+    pub expires_at: DateTime<Utc>,
+    pub scope: String,
+}
+
+pub struct PgWithingsCredentialsRepository<'a> {
+    pool: &'a PgPool,
+}
+
+impl<'a> PgWithingsCredentialsRepository<'a> {
+    pub(crate) fn new(pool: &'a PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[instrument(skip(self, creds))]
+    pub async fn upsert(&self, creds: &WithingsCredentials) -> StorageResult<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO withings_credentials
+                (user_id, access_token_enc, refresh_token_enc, expires_at, scope)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (user_id) DO UPDATE SET
+                access_token_enc  = EXCLUDED.access_token_enc,
+                refresh_token_enc = EXCLUDED.refresh_token_enc,
+                expires_at        = EXCLUDED.expires_at,
+                scope             = EXCLUDED.scope,
+                updated_at        = now()
+            "#,
+            creds.user_id,
+            creds.access_token_enc,
+            creds.refresh_token_enc,
+            creds.expires_at,
+            creds.scope,
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get(&self, user_id: Uuid) -> StorageResult<Option<WithingsCredentials>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT user_id, access_token_enc, refresh_token_enc, expires_at, scope
+            FROM withings_credentials
+            WHERE user_id = $1
+            "#,
+            user_id
+        )
+        .fetch_optional(self.pool)
+        .await?;
+        Ok(row.map(|r| WithingsCredentials {
+            user_id: r.user_id,
+            access_token_enc: r.access_token_enc,
+            refresh_token_enc: r.refresh_token_enc,
+            expires_at: r.expires_at,
+            scope: r.scope,
+        }))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn delete(&self, user_id: Uuid) -> StorageResult<()> {
+        sqlx::query!(
+            "DELETE FROM withings_credentials WHERE user_id = $1",
+            user_id
+        )
+        .execute(self.pool)
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/storage/src/rows.rs
+++ b/crates/storage/src/rows.rs
@@ -1,0 +1,136 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::FromRow;
+use stadera_domain::{
+    ActivityLevel, BodyFatPercent, Height, LeanMass, Measurement, Sex, Source, UserProfile, Weight,
+};
+use uuid::Uuid;
+
+use crate::error::StorageError;
+
+#[derive(FromRow)]
+#[allow(dead_code)] // id/user_id/created_at mirror the DB schema for query_as! matching; not used by the domain conversion.
+pub(crate) struct MeasurementRow {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub taken_at: DateTime<Utc>,
+    pub weight_kg: f64,
+    pub body_fat_percent: Option<f64>,
+    pub lean_mass_kg: Option<f64>,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TryFrom<MeasurementRow> for Measurement {
+    type Error = StorageError;
+
+    fn try_from(r: MeasurementRow) -> Result<Self, Self::Error> {
+        let weight = Weight::new(r.weight_kg)
+            .map_err(|e| StorageError::corruption("measurements", e.to_string()))?;
+
+        let body_fat = r
+            .body_fat_percent
+            .map(BodyFatPercent::new)
+            .transpose()
+            .map_err(|e| StorageError::corruption("measurements", e.to_string()))?;
+
+        let lean_mass = r
+            .lean_mass_kg
+            .map(LeanMass::new)
+            .transpose()
+            .map_err(|e| StorageError::corruption("measurements", e.to_string()))?;
+
+        let source = match r.source.as_str() {
+            "withings" => Source::Withings,
+            "manual" => Source::Manual,
+            other => {
+                return Err(StorageError::corruption(
+                    "measurements",
+                    format!("invalid source: {other}"),
+                ));
+            }
+        };
+
+        Ok(Measurement::new(
+            r.taken_at, weight, body_fat, lean_mass, source,
+        ))
+    }
+}
+
+#[derive(FromRow)]
+#[allow(dead_code)] // user_id/updated_at mirror the DB schema; not part of the UserProfile domain type.
+pub(crate) struct UserProfilesRow {
+    pub user_id: Uuid,
+    pub sex: String,
+    pub birth_date: NaiveDate,
+    pub height_cm: f64,
+    pub activity_level: String,
+    pub goal_weight_kg: f64,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<UserProfilesRow> for UserProfile {
+    type Error = StorageError;
+
+    fn try_from(r: UserProfilesRow) -> Result<Self, Self::Error> {
+        let sex = match r.sex.as_str() {
+            "male" => Sex::Male,
+            "female" => Sex::Female,
+            other => {
+                return Err(StorageError::corruption(
+                    "user_profiles",
+                    format!("invalid sex: {other}"),
+                ));
+            }
+        };
+
+        let activity = match r.activity_level.as_str() {
+            "sedentary" => ActivityLevel::Sedentary,
+            "lightly_active" => ActivityLevel::LightlyActive,
+            "moderately_active" => ActivityLevel::ModeratelyActive,
+            "very_active" => ActivityLevel::VeryActive,
+            other => {
+                return Err(StorageError::corruption(
+                    "user_profiles",
+                    format!("invalid activity_level: {other}"),
+                ));
+            }
+        };
+
+        let height = Height::new(r.height_cm)
+            .map_err(|e| StorageError::corruption("user_profiles", e.to_string()))?;
+
+        let goal_weight = Weight::new(r.goal_weight_kg)
+            .map_err(|e| StorageError::corruption("user_profiles", e.to_string()))?;
+
+        Ok(UserProfile {
+            birth_date: r.birth_date,
+            sex,
+            height,
+            activity,
+            goal_weight,
+        })
+    }
+}
+
+pub(crate) fn source_to_str(s: Source) -> &'static str {
+    match s {
+        Source::Withings => "withings",
+        Source::Manual => "manual",
+    }
+}
+
+pub(crate) fn sex_to_str(s: Sex) -> &'static str {
+    match s {
+        Sex::Male => "male",
+        Sex::Female => "female",
+    }
+}
+
+pub(crate) fn activity_level_to_str(a: ActivityLevel) -> &'static str {
+    match a {
+        ActivityLevel::Sedentary => "sedentary",
+        ActivityLevel::LightlyActive => "lightly_active",
+        ActivityLevel::ModeratelyActive => "moderately_active",
+        ActivityLevel::VeryActive => "very_active",
+    }
+}

--- a/crates/storage/tests/test_measurement_repo.rs
+++ b/crates/storage/tests/test_measurement_repo.rs
@@ -1,0 +1,214 @@
+use chrono::{TimeZone, Utc};
+use sqlx::PgPool;
+use stadera_domain::{BodyFatPercent, LeanMass, Measurement, Source, Weight};
+use stadera_storage::StorageContext;
+use uuid::Uuid;
+
+async fn create_test_user(ctx: &StorageContext) -> Uuid {
+    ctx.users()
+        .create("test@example.com", "Test")
+        .await
+        .unwrap()
+}
+
+fn sample_measurement(day: u32) -> Measurement {
+    Measurement::new(
+        Utc.with_ymd_and_hms(2026, 4, day, 8, 0, 0).unwrap(),
+        Weight::new(80.0).unwrap(),
+        Some(BodyFatPercent::new(20.0).unwrap()),
+        Some(LeanMass::new(64.0).unwrap()),
+        Source::Withings,
+    )
+}
+
+#[sqlx::test]
+async fn insert_and_get_by_id(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+    let m = sample_measurement(24);
+
+    let id = ctx.measurements().insert(user_id, &m).await.unwrap();
+    let got = ctx.measurements().get_by_id(id).await.unwrap().unwrap();
+
+    assert_eq!(got.taken_at, m.taken_at);
+    assert_eq!(got.weight.value(), m.weight.value());
+    assert_eq!(
+        got.body_fat.map(|bf| bf.value()),
+        m.body_fat.map(|bf| bf.value())
+    );
+    assert_eq!(
+        got.lean_mass.map(|lm| lm.value()),
+        m.lean_mass.map(|lm| lm.value())
+    );
+    assert_eq!(got.source, m.source);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn insert_without_optional_fields(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+    let m = Measurement::new(
+        Utc.with_ymd_and_hms(2026, 4, 24, 8, 0, 0).unwrap(),
+        Weight::new(75.0).unwrap(),
+        None,
+        None,
+        Source::Manual,
+    );
+
+    let id = ctx.measurements().insert(user_id, &m).await.unwrap();
+    let got = ctx.measurements().get_by_id(id).await.unwrap().unwrap();
+
+    assert!(got.body_fat.is_none());
+    assert!(got.lean_mass.is_none());
+    assert_eq!(got.source, Source::Manual);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_by_id_non_existent_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = Uuid::now_v7();
+    assert!(ctx.measurements().get_by_id(id).await.unwrap().is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn list_for_user_between_filters_window(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    for day in [20u32, 22, 25] {
+        ctx.measurements()
+            .insert(user_id, &sample_measurement(day))
+            .await
+            .unwrap();
+    }
+
+    let from = Utc.with_ymd_and_hms(2026, 4, 21, 0, 0, 0).unwrap();
+    let to = Utc.with_ymd_and_hms(2026, 4, 24, 0, 0, 0).unwrap();
+    let results = ctx
+        .measurements()
+        .list_for_user_between(user_id, from, to)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].taken_at.timestamp(),
+        sample_measurement(22).taken_at.timestamp()
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn list_for_user_between_ordered_asc(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    // insert in reverse order
+    for day in [25u32, 22, 20] {
+        ctx.measurements()
+            .insert(user_id, &sample_measurement(day))
+            .await
+            .unwrap();
+    }
+
+    let from = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+    let to = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+    let results = ctx
+        .measurements()
+        .list_for_user_between(user_id, from, to)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 3);
+    assert!(results[0].taken_at < results[1].taken_at);
+    assert!(results[1].taken_at < results[2].taken_at);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn latest_for_user(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    for day in [20u32, 22, 25] {
+        ctx.measurements()
+            .insert(user_id, &sample_measurement(day))
+            .await
+            .unwrap();
+    }
+
+    let latest = ctx
+        .measurements()
+        .latest_for_user(user_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest.taken_at, sample_measurement(25).taken_at);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn latest_for_user_no_measurements_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    assert!(
+        ctx.measurements()
+            .latest_for_user(user_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn list_for_user_latest_respects_limit_and_order(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    for day in 20u32..=24 {
+        ctx.measurements()
+            .insert(user_id, &sample_measurement(day))
+            .await
+            .unwrap();
+    }
+
+    let latest3 = ctx
+        .measurements()
+        .list_for_user_latest(user_id, 3)
+        .await
+        .unwrap();
+    assert_eq!(latest3.len(), 3);
+    // DESC order: first is the most recent
+    assert!(latest3[0].taken_at > latest3[1].taken_at);
+    assert!(latest3[1].taken_at > latest3[2].taken_at);
+    assert_eq!(latest3[0].taken_at, sample_measurement(24).taken_at);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn insert_batch(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    let measurements: Vec<Measurement> = (20u32..=22).map(sample_measurement).collect();
+
+    let ids = ctx
+        .measurements()
+        .insert_batch(user_id, &measurements)
+        .await
+        .unwrap();
+    assert_eq!(ids.len(), 3);
+
+    let all = ctx
+        .measurements()
+        .list_for_user_latest(user_id, 10)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+    Ok(())
+}

--- a/crates/storage/tests/test_measurement_repo.rs
+++ b/crates/storage/tests/test_measurement_repo.rs
@@ -212,3 +212,32 @@ async fn insert_batch(pool: PgPool) -> sqlx::Result<()> {
     assert_eq!(all.len(), 3);
     Ok(())
 }
+
+#[sqlx::test]
+async fn insert_batch_rolls_back_on_failure(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+
+    // A user_id not present in `users` → FK violation on the first INSERT,
+    // which should abort the transaction and leave no partial state.
+    let fake_user_id = Uuid::now_v7();
+    let measurements: Vec<Measurement> = (20u32..=22).map(sample_measurement).collect();
+
+    let result = ctx
+        .measurements()
+        .insert_batch(fake_user_id, &measurements)
+        .await;
+    assert!(result.is_err(), "expected FK violation to fail the batch");
+
+    // Create a real user afterward: no rows should have leaked into `measurements`.
+    let real_user_id = create_test_user(&ctx).await;
+    let all = ctx
+        .measurements()
+        .list_for_user_latest(real_user_id, 100)
+        .await
+        .unwrap();
+    assert!(
+        all.is_empty(),
+        "rollback should have left the measurements table empty for any user"
+    );
+    Ok(())
+}

--- a/crates/storage/tests/test_user_profile_repo.rs
+++ b/crates/storage/tests/test_user_profile_repo.rs
@@ -1,0 +1,81 @@
+use chrono::NaiveDate;
+use sqlx::PgPool;
+use stadera_domain::{ActivityLevel, Height, Sex, UserProfile, Weight};
+use stadera_storage::StorageContext;
+use uuid::Uuid;
+
+fn sample_profile() -> UserProfile {
+    UserProfile {
+        birth_date: NaiveDate::from_ymd_opt(1990, 6, 15).unwrap(),
+        sex: Sex::Male,
+        height: Height::new(175.0).unwrap(),
+        activity: ActivityLevel::ModeratelyActive,
+        goal_weight: Weight::new(75.0).unwrap(),
+    }
+}
+
+async fn create_test_user(ctx: &StorageContext) -> Uuid {
+    ctx.users()
+        .create("test@example.com", "Test")
+        .await
+        .unwrap()
+}
+
+#[sqlx::test]
+async fn upsert_and_get_roundtrip(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+    let profile = sample_profile();
+
+    ctx.user_profiles().upsert(user_id, &profile).await.unwrap();
+    let got = ctx
+        .user_profiles()
+        .get_for_user(user_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(got.birth_date, profile.birth_date);
+    assert_eq!(got.sex, profile.sex);
+    assert_eq!(got.height.value(), profile.height.value());
+    assert_eq!(got.activity, profile.activity);
+    assert_eq!(got.goal_weight.value(), profile.goal_weight.value());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn upsert_updates_existing(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    let mut profile = sample_profile();
+    ctx.user_profiles().upsert(user_id, &profile).await.unwrap();
+
+    profile.goal_weight = Weight::new(70.0).unwrap();
+    profile.activity = ActivityLevel::VeryActive;
+    ctx.user_profiles().upsert(user_id, &profile).await.unwrap();
+
+    let got = ctx
+        .user_profiles()
+        .get_for_user(user_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.goal_weight.value(), 70.0);
+    assert_eq!(got.activity, ActivityLevel::VeryActive);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_non_existent_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = Uuid::now_v7();
+    assert!(
+        ctx.user_profiles()
+            .get_for_user(id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    Ok(())
+}

--- a/crates/storage/tests/test_user_repo.rs
+++ b/crates/storage/tests/test_user_repo.rs
@@ -1,0 +1,71 @@
+use sqlx::PgPool;
+use stadera_storage::StorageContext;
+use uuid::Uuid;
+
+#[sqlx::test]
+async fn create_and_get_by_id(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = ctx
+        .users()
+        .create("alice@example.com", "Alice")
+        .await
+        .unwrap();
+
+    let user = ctx.users().get_by_id(id).await.unwrap().unwrap();
+    assert_eq!(user.id, id);
+    assert_eq!(user.email, "alice@example.com");
+    assert_eq!(user.name, "Alice");
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_by_email(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    ctx.users().create("bob@example.com", "Bob").await.unwrap();
+
+    let user = ctx
+        .users()
+        .get_by_email("bob@example.com")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(user.email, "bob@example.com");
+    assert_eq!(user.name, "Bob");
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_by_id_non_existent_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = Uuid::now_v7();
+    assert!(ctx.users().get_by_id(id).await.unwrap().is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_by_email_non_existent_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    assert!(
+        ctx.users()
+            .get_by_email("missing@example.com")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn duplicate_email_rejected(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    ctx.users()
+        .create("dup@example.com", "First")
+        .await
+        .unwrap();
+    let result = ctx.users().create("dup@example.com", "Second").await;
+    assert!(
+        result.is_err(),
+        "expected UNIQUE violation on duplicate email"
+    );
+    Ok(())
+}

--- a/crates/storage/tests/test_withings_credentials_repo.rs
+++ b/crates/storage/tests/test_withings_credentials_repo.rs
@@ -1,0 +1,97 @@
+use chrono::{TimeZone, Utc};
+use sqlx::PgPool;
+use stadera_storage::{StorageContext, WithingsCredentials};
+use uuid::Uuid;
+
+async fn create_test_user(ctx: &StorageContext) -> Uuid {
+    ctx.users()
+        .create("test@example.com", "Test")
+        .await
+        .unwrap()
+}
+
+fn sample_credentials(user_id: Uuid) -> WithingsCredentials {
+    WithingsCredentials {
+        user_id,
+        access_token_enc: vec![1, 2, 3, 4],
+        refresh_token_enc: vec![5, 6, 7, 8],
+        expires_at: Utc.with_ymd_and_hms(2027, 1, 1, 0, 0, 0).unwrap(),
+        scope: "user.metrics".to_string(),
+    }
+}
+
+#[sqlx::test]
+async fn upsert_and_get_roundtrip(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+    let creds = sample_credentials(user_id);
+
+    ctx.withings_credentials().upsert(&creds).await.unwrap();
+    let got = ctx
+        .withings_credentials()
+        .get(user_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(got.user_id, creds.user_id);
+    assert_eq!(got.access_token_enc, creds.access_token_enc);
+    assert_eq!(got.refresh_token_enc, creds.refresh_token_enc);
+    assert_eq!(got.expires_at, creds.expires_at);
+    assert_eq!(got.scope, creds.scope);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn upsert_updates_existing(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    let mut creds = sample_credentials(user_id);
+    ctx.withings_credentials().upsert(&creds).await.unwrap();
+
+    creds.access_token_enc = vec![9, 9, 9];
+    creds.scope = "user.metrics,user.info".to_string();
+    ctx.withings_credentials().upsert(&creds).await.unwrap();
+
+    let got = ctx
+        .withings_credentials()
+        .get(user_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.access_token_enc, vec![9, 9, 9]);
+    assert_eq!(got.scope, "user.metrics,user.info");
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_removes_row(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+    let creds = sample_credentials(user_id);
+
+    ctx.withings_credentials().upsert(&creds).await.unwrap();
+    ctx.withings_credentials().delete(user_id).await.unwrap();
+
+    let got = ctx.withings_credentials().get(user_id).await.unwrap();
+    assert!(got.is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_non_existent_returns_none(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = Uuid::now_v7();
+    assert!(ctx.withings_credentials().get(id).await.unwrap().is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_non_existent_is_noop(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let id = Uuid::now_v7();
+    // Deleting something that doesn't exist should not error
+    ctx.withings_credentials().delete(id).await.unwrap();
+    Ok(())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"   # o più recente, es. "1.90"
+channel = "1.89"   # edition 2024 needs ≥1.85; sqlx-cli 0.8.x transitive deps need ≥1.88
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
Second (and final) PR for M3. Introduces the repository layer over the schema defined in PR #3:
`StorageContext` façade, 4 `Pg*Repository` types, DTO row structs with `TryFrom` to domain,
typed error handling. Adds integration tests with `sqlx::test` and wires the CI Postgres
service required by `sqlx::query!` compile-time checks.

## Motivation / Context
- Milestone: M3 (closes the milestone with repository + tests + CI)

## Changes
- \`StorageContext\` (lib.rs) with factory methods per repository, concrete \`Pg*Repository\` structs
- Repositories: measurement (insert/insert_batch/get_by_id/list_between/list_latest/latest), user
  (create/get_by_id/get_by_email), user_profile (upsert/get_for_user),
  withings_credentials (upsert/get/delete)
- DTO rows (\`MeasurementRow\`, \`UserProfilesRow\`) with \`TryFrom\` to domain; helpers
  \`source_to_str\`, \`sex_to_str\`, \`activity_level_to_str\`
- \`StorageError\` with \`Database(#[from] sqlx::Error)\` and \`Corruption { table, msg }\`
- \`#[tracing::instrument]\` on all repo methods (skip sensitive fields)
- 22 integration tests with \`sqlx::test\` (DB-per-test template isolation)
- CI: postgres:16-alpine service in \`clippy\` and \`test\` jobs, \`sqlx-cli\` install + migrate step
- Re-exports: \`User\`, \`WithingsCredentials\` at crate root

## Test plan
- [x] cargo fmt / clippy -D warnings / test --all all green locally
- [x] All 22 integration tests pass against docker postgres 16
- [x] Workspace test count: 67 (45 domain + 22 storage)

## Notes for reviewer
- \`#[allow(dead_code)]\` on \`MeasurementRow\` / \`UserProfilesRow\` is deliberate: fields mirror the
  DB schema for \`sqlx::query_as!\` compile-time matching but some aren't read by the domain mapping.
- \`sqlx::test\` uses the default migrations path (\`./migrations\` relative to the crate root),
  no explicit \`migrations = \"...\"\` attribute needed.
- CI installs \`sqlx-cli\` each run (~90s). If build time becomes a concern, consider
  \`baptiste0928/cargo-install\` with caching or \`cargo-binstall\`.