### PR TITLE
feat(withings): OAuth2 client + Health Mate API client + first-time pair tool

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -71,8 +71,8 @@ stadera/
 |---|---|---|---|
 | M1 | Foundations | ✅ Done | Workspace, CI, release-please, conventional commits |
 | M2 | Domain core | ✅ Done | Merged via PR #2 (squashed into `1507c18`). Domain blockers resolved. Follow-ups tracked in `reviews/pr-2.md` |
-| M3 | Storage | ⏳ In progress | PR A `feat/storage-scaffold` merged (#3). PR B `feat/storage-repositories` open: repositories + integration tests + CI Postgres service |
-| M4 | Withings integration | 📋 Planned | OAuth2 flow, token refresh, API client, sync binary. Multi-tenant DB schema ready |
+| M3 | Storage | ✅ Done | Both PRs merged: scaffold (#3) and repositories+tests (#5). Closed `1507c18..4730651` |
+| M4 | Withings integration | ⏳ In progress | OAuth2 flow + Health Mate API client + token refresh (`crates/withings`) and sync cron binary (`crates/jobs`). Multi-tenant DB schema ready since M3 |
 | M5 | API + Frontend | 📋 Planned | axum endpoints (`/today`, `/trend`, `/history`), OAuth Google auth middleware, utoipa/Swagger. `stadera-web` repo scaffolded |
 | M6 | Notifications | 📋 Planned | Pushover daily job, Resend weekly digest (Apple-weekly-summary style) |
 | M7 | Cloud deploy | 📋 Planned | Terraform, GitHub Actions deploy, Dockerfile multi-stage, Vercel for frontend |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .env.local
 
 .DS_Store
+
+.secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "stadera-withings"
+version = "0.1.0"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,47 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +68,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "atoi"
@@ -40,6 +153,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -127,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +264,79 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -186,6 +384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,8 +414,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -310,6 +545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +584,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -386,6 +646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,8 +674,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -429,8 +702,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -440,9 +715,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -456,6 +733,35 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -491,6 +797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +833,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -669,6 +1087,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +1129,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -761,6 +1212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +1241,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -852,10 +1319,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking"
@@ -941,6 +1450,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1522,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -1110,6 +1686,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1713,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
 
 [[package]]
 name = "ring"
@@ -1161,6 +1787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1825,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1287,6 +1920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1998,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1441,7 +2091,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1526,7 +2176,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -1565,7 +2215,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -1591,7 +2241,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -1621,7 +2271,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1632,7 +2282,7 @@ dependencies = [
  "serde",
  "sqlx",
  "stadera-domain",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1641,6 +2291,28 @@ dependencies = [
 [[package]]
 name = "stadera-withings"
 version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "chrono",
+ "clap",
+ "hex",
+ "oauth2",
+ "rand 0.9.4",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "stadera-domain",
+ "stadera-storage",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "wiremock",
+]
 
 [[package]]
 name = "stringprep"
@@ -1652,6 +2324,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1668,6 +2346,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1696,11 +2383,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1777,6 +2484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +2503,69 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1850,6 +2630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +2681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +2706,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1917,6 +2714,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -1955,6 +2758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1998,6 +2810,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2064,6 +2886,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2300,6 +3142,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "dotenvy",
  "hex",
  "oauth2",
  "rand 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/api", "crates/domain", "crates/storage"]
+members = ["crates/api", "crates/domain", "crates/storage", "crates/withings"]
 
 [workspace.package]
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,5 @@ url = "2"
 clap = { version = "4", features = ["derive"] }
 # HTTP mocking for tests
 wiremock = "0.6"
+# .env auto-load for setup binaries
+dotenvy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,17 @@ sqlx = { version = "0.8", default-features = false, features = [
 ] }
 uuid = { version = "1", features = ["v7", "serde"] }
 serde_json = "1"
+# http client
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip"] }
+# oauth2 RFC 6749 client
+oauth2 = "5"
+# AEAD symmetric encryption for stored tokens
+aes-gcm = "0.10"
+rand = "0.9"
+hex = "0.4"
+# url parsing (callback handling in pair binary)
+url = "2"
+# CLI argument parsing for binaries
+clap = { version = "4", features = ["derive"] }
+# HTTP mocking for tests
+wiremock = "0.6"

--- a/crates/storage/migrations/20260425090000_measurement_idempotency.sql
+++ b/crates/storage/migrations/20260425090000_measurement_idempotency.sql
@@ -1,0 +1,15 @@
+-- Add UNIQUE constraint on measurements for idempotent inserts during Withings sync.
+--
+-- Without this, retrying a sync after a partial failure (or after Withings
+-- returns an overlapping window of measurements on a subsequent poll) would
+-- create duplicate rows: each insert generates a fresh UUID v7 PK, so PK
+-- uniqueness is not a guard.
+--
+-- (user_id, taken_at, source) is the natural business key: a single user
+-- never has two measurements at the exact same instant from the same source.
+-- Manual entries that happen to land on the same second as a Withings reading
+-- are still distinguishable thanks to `source`.
+
+ALTER TABLE measurements
+    ADD CONSTRAINT measurements_user_taken_at_source_key
+    UNIQUE (user_id, taken_at, source);

--- a/crates/withings/Cargo.toml
+++ b/crates/withings/Cargo.toml
@@ -6,3 +6,26 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+stadera-domain = { path = "../domain" }
+stadera-storage = { path = "../storage" }
+reqwest.workspace = true
+oauth2.workspace = true
+aes-gcm.workspace = true
+rand.workspace = true
+hex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tokio.workspace = true
+sqlx.workspace = true
+url.workspace = true
+clap.workspace = true
+uuid.workspace = true
+anyhow.workspace = true
+
+[dev-dependencies]
+wiremock.workspace = true
+tokio = { workspace = true }

--- a/crates/withings/Cargo.toml
+++ b/crates/withings/Cargo.toml
@@ -25,6 +25,7 @@ url.workspace = true
 clap.workspace = true
 uuid.workspace = true
 anyhow.workspace = true
+dotenvy.workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/withings/Cargo.toml
+++ b/crates/withings/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "stadera-withings"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/crates/withings/src/bin/pair.rs
+++ b/crates/withings/src/bin/pair.rs
@@ -1,18 +1,230 @@
-//! One-shot CLI tool for first-time OAuth pairing with Withings.
-//!
-//! Flow:
-//! 1. Print the Withings authorization URL.
-//! 2. Open the user's browser at it.
-//! 3. Listen on `http://localhost:7878/callback` for the redirect with `?code=...`.
-//! 4. Exchange the code for tokens via Withings token endpoint.
-//! 5. Encrypt tokens and persist them via `stadera-storage`.
-//!
-//! Run once during initial setup; thereafter the cron sync uses the stored refresh token.
+// One-shot CLI tool for first-time OAuth pairing with Withings.
 
-fn main() {
-    eprintln!(
-        "stadera-withings pair: not yet implemented. \
-         Will be filled in by feat(withings) work in M4."
+use std::io::{BufRead, BufReader, Write};
+
+use anyhow::{Context, bail};
+use chrono::{Duration, Utc};
+use clap::Parser;
+use sqlx::PgPool;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+use stadera_storage::{StorageContext, WithingsCredentials};
+use stadera_withings::crypto;
+use stadera_withings::oauth::WithingsOauth;
+
+/// One-shot Withings OAuth pairing tool for Stadera.
+#[derive(Parser)]
+#[command(name = "stadera-pair")]
+struct Cli {
+    /// Email of the user to pair.
+    #[arg(long)]
+    user_email: String,
+
+    /// Display name for the user (defaults to email if omitted).
+    #[arg(long)]
+    user_name: Option<String>,
+}
+
+const REDIRECT_URI: &str = "http://localhost:7878/callback";
+const SCOPES: &[&str] = &["user.metrics"];
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    // --- 1. Read env ---
+    let client_id =
+        std::env::var("WITHINGS_CLIENT_ID").context("WITHINGS_CLIENT_ID env var is required")?;
+    let client_secret = std::env::var("WITHINGS_CLIENT_SECRET")
+        .context("WITHINGS_CLIENT_SECRET env var is required")?;
+    let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL env var is required")?;
+
+    // Build cipher early so we fail fast if the key is missing/invalid.
+    let cipher = crypto::cipher_from_env()
+        .context("failed to load encryption key from WITHINGS_TOKEN_KEY")?;
+
+    // --- 2. Build authorization URL ---
+    let oauth = WithingsOauth::new(client_id, client_secret, REDIRECT_URI.to_string())
+        .context("failed to build WithingsOauth")?;
+
+    let (auth_url, csrf_state) = oauth.authorization_url(SCOPES);
+
+    // --- 3. Print URL ---
+    println!("\nOpen this URL in your browser to authorize Stadera:\n");
+    println!("  {auth_url}\n");
+    println!("Waiting for callback on {REDIRECT_URI} …\n");
+
+    // --- 4. Spawn TCP listener ---
+    let listener = TcpListener::bind("127.0.0.1:7878")
+        .await
+        .context("failed to bind to 127.0.0.1:7878")?;
+
+    // --- 5. Accept ONE connection, parse the callback ---
+    let (stream, _addr) = listener
+        .accept()
+        .await
+        .context("failed to accept connection")?;
+
+    // Read the first HTTP request line from the TCP stream.
+    let std_stream = stream
+        .into_std()
+        .context("failed to convert tokio stream to std")?;
+    std_stream
+        .set_nonblocking(false)
+        .context("failed to set blocking mode")?;
+    let mut reader = BufReader::new(&std_stream);
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .context("failed to read HTTP request line")?;
+
+    // Parse "GET /callback?code=...&state=... HTTP/1.1"
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .context("malformed HTTP request line")?
+        .to_string();
+
+    // Drain remaining HTTP headers so the browser doesn't see a connection reset.
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+
+    let full_url = Url::parse(&format!("http://localhost:7878{path}"))
+        .context("failed to parse callback URL")?;
+
+    let params: std::collections::HashMap<String, String> = full_url
+        .query_pairs()
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    let code = params
+        .get("code")
+        .context("callback is missing `code` parameter")?;
+    let state = params
+        .get("state")
+        .context("callback is missing `state` parameter")?;
+
+    // --- 6. Validate CSRF state ---
+    if state != csrf_state.secret() {
+        // Write error page before bailing.
+        let error_html = "HTTP/1.1 400 Bad Request\r\n\
+            Content-Type: text/html; charset=utf-8\r\n\
+            Connection: close\r\n\r\n\
+            <h1>CSRF state mismatch</h1>\
+            <p>The state parameter does not match. Please try again.</p>";
+        write_response(&std_stream, error_html);
+        bail!(
+            "CSRF state mismatch: expected {}, got {state}",
+            csrf_state.secret()
+        );
+    }
+
+    info!("received valid callback, exchanging code for tokens …");
+
+    // --- 7. Exchange code for tokens ---
+    let tokens = oauth
+        .exchange_code(code)
+        .await
+        .context("failed to exchange authorization code for tokens")?;
+
+    info!(userid = %tokens.userid, scope = %tokens.scope, "token exchange successful");
+
+    // --- 8. Connect Postgres ---
+    let pool = PgPool::connect(&database_url)
+        .await
+        .context("failed to connect to Postgres")?;
+
+    let storage = StorageContext::new(pool);
+
+    // --- 9. Look up user by email (or create if missing) ---
+    let user = match storage.users().get_by_email(&cli.user_email).await? {
+        Some(u) => {
+            info!(user_id = %u.id, "found existing user");
+            u
+        }
+        None => {
+            warn!(email = %cli.user_email, "user not found — creating");
+            let name = cli.user_name.as_deref().unwrap_or(&cli.user_email);
+            let id = storage.users().create(&cli.user_email, name).await?;
+            storage
+                .users()
+                .get_by_id(id)
+                .await?
+                .context("failed to read back newly created user")?
+        }
+    };
+
+    // --- 10. Encrypt tokens ---
+    let access_token_enc = crypto::encrypt(&cipher, tokens.access_token.as_bytes())
+        .context("failed to encrypt access token")?;
+    let refresh_token_enc = crypto::encrypt(&cipher, tokens.refresh_token.as_bytes())
+        .context("failed to encrypt refresh token")?;
+
+    let expires_at = Utc::now() + Duration::seconds(tokens.expires_in);
+
+    // --- 11. Upsert credentials ---
+    let creds = WithingsCredentials {
+        user_id: user.id,
+        access_token_enc,
+        refresh_token_enc,
+        expires_at,
+        scope: tokens.scope,
+    };
+
+    storage
+        .withings_credentials()
+        .upsert(&creds)
+        .await
+        .context("failed to upsert Withings credentials")?;
+
+    info!(user_id = %user.id, "credentials stored successfully");
+
+    // --- 12. Write success HTML page, flush, and close ---
+    let success_html = "HTTP/1.1 200 OK\r\n\
+        Content-Type: text/html; charset=utf-8\r\n\
+        Connection: close\r\n\r\n\
+        <!DOCTYPE html>\
+        <html><body>\
+        <h1>Stadera paired successfully!</h1>\
+        <p>You can close this tab and return to the terminal.</p>\
+        </body></html>";
+    let mut writable = std_stream;
+    writable.write_all(success_html.as_bytes())?;
+    writable.flush()?;
+    drop(writable);
+
+    // --- 13. Exit cleanly ---
+    println!(
+        "Pairing complete for {}. You can close this terminal.",
+        cli.user_email
     );
-    std::process::exit(1);
+
+    Ok(())
+}
+
+/// Best-effort write to the TCP stream; used for error responses before bail.
+fn write_response(stream: &std::net::TcpStream, response: &str) {
+    use std::io::Write;
+    if let Err(e) = stream.try_clone().and_then(|mut s| {
+        s.write_all(response.as_bytes())?;
+        s.flush()
+    }) {
+        warn!("failed to write HTTP response to browser: {e}");
+    }
 }

--- a/crates/withings/src/bin/pair.rs
+++ b/crates/withings/src/bin/pair.rs
@@ -1,0 +1,18 @@
+//! One-shot CLI tool for first-time OAuth pairing with Withings.
+//!
+//! Flow:
+//! 1. Print the Withings authorization URL.
+//! 2. Open the user's browser at it.
+//! 3. Listen on `http://localhost:7878/callback` for the redirect with `?code=...`.
+//! 4. Exchange the code for tokens via Withings token endpoint.
+//! 5. Encrypt tokens and persist them via `stadera-storage`.
+//!
+//! Run once during initial setup; thereafter the cron sync uses the stored refresh token.
+
+fn main() {
+    eprintln!(
+        "stadera-withings pair: not yet implemented. \
+         Will be filled in by feat(withings) work in M4."
+    );
+    std::process::exit(1);
+}

--- a/crates/withings/src/bin/pair.rs
+++ b/crates/withings/src/bin/pair.rs
@@ -33,6 +33,10 @@ const SCOPES: &[&str] = &["user.metrics"];
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Auto-load `.env` from cwd (or any ancestor). No-op in production where the
+    // file is absent — env vars are injected by the runtime (Cloud Run secrets).
+    let _ = dotenvy::dotenv();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),

--- a/crates/withings/src/client.rs
+++ b/crates/withings/src/client.rs
@@ -1,0 +1,7 @@
+//! Health Mate API client.
+//!
+//! Endpoints used by Stadera:
+//! - `/measure?action=getmeas` — list weight measurements for a user
+//!
+//! The client wraps `reqwest`, adds bearer-token auth from a `WithingsCredentials`,
+//! and decodes the JSON envelope (`status`, `body`, `error`) used by Withings.

--- a/crates/withings/src/client.rs
+++ b/crates/withings/src/client.rs
@@ -1,7 +1,88 @@
 //! Health Mate API client.
 //!
-//! Endpoints used by Stadera:
-//! - `/measure?action=getmeas` — list weight measurements for a user
+//! Wraps `reqwest`, adds bearer-token auth, and decodes Withings' envelope
+//! (`{ "status": ..., "body": ..., "error": ... }`) for each endpoint.
 //!
-//! The client wraps `reqwest`, adds bearer-token auth from a `WithingsCredentials`,
-//! and decodes the JSON envelope (`status`, `body`, `error`) used by Withings.
+//! Endpoints implemented:
+//! - `POST /measure` (action=getmeas) — list weight/body-fat/lean-mass
+//!   measurements for the authenticated user
+
+use chrono::{DateTime, Utc};
+
+use crate::error::{WithingsError, WithingsResult};
+use crate::types::{ApiEnvelope, GetMeasBody, MeasureGroup, measure_type};
+
+const DEFAULT_BASE_URL: &str = "https://wbsapi.withings.net";
+
+/// Health Mate API client.
+pub struct WithingsClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl WithingsClient {
+    /// Construct with the production Withings base URL.
+    pub fn new() -> WithingsResult<Self> {
+        Self::with_base_url(DEFAULT_BASE_URL.to_string())
+    }
+
+    /// Construct with an explicit base URL (used by tests with mock servers).
+    pub fn with_base_url(base_url: String) -> WithingsResult<Self> {
+        Ok(Self {
+            base_url,
+            http: reqwest::Client::builder()
+                .build()
+                .map_err(WithingsError::Http)?,
+        })
+    }
+
+    /// Fetch measurement groups for the authenticated user, in `[from, to]`
+    /// (Withings interprets `startdate`/`enddate` as inclusive Unix seconds).
+    ///
+    /// `access_token` is the bearer token (already decrypted by the caller).
+    /// Only weight, lean mass, and body-fat-percent measurement types are
+    /// requested (`meastypes=1,5,6`).
+    pub async fn get_measurements(
+        &self,
+        access_token: &str,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> WithingsResult<Vec<MeasureGroup>> {
+        let meastypes = format!(
+            "{},{},{}",
+            measure_type::WEIGHT_KG,
+            measure_type::LEAN_MASS_KG,
+            measure_type::BODY_FAT_PERCENT,
+        );
+        let startdate = from.timestamp().to_string();
+        let enddate = to.timestamp().to_string();
+
+        let envelope: ApiEnvelope<GetMeasBody> = self
+            .http
+            .post(format!("{}/measure", self.base_url))
+            .bearer_auth(access_token)
+            .form(&[
+                ("action", "getmeas"),
+                ("meastypes", meastypes.as_str()),
+                ("category", "1"), // 1 = real measurements (exclude objectives)
+                ("startdate", startdate.as_str()),
+                ("enddate", enddate.as_str()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        if !envelope.is_success() {
+            return Err(WithingsError::Api {
+                status: envelope.status,
+                message: envelope.error.unwrap_or_default(),
+            });
+        }
+        let body = envelope
+            .body
+            .ok_or_else(|| WithingsError::UnexpectedResponse("status=0 but body is null".into()))?;
+        Ok(body.measuregrps)
+    }
+}

--- a/crates/withings/src/crypto.rs
+++ b/crates/withings/src/crypto.rs
@@ -1,6 +1,166 @@
 //! Token encryption (AES-256-GCM).
 //!
-//! Encryption layer for `access_token` and `refresh_token` stored in
-//! `withings_credentials.access_token_enc` / `refresh_token_enc` (BYTEA).
-//! Layout per encrypted blob: `nonce(12 bytes) || ciphertext || tag(16 bytes)`.
-//! Key is loaded from `WITHINGS_TOKEN_KEY` (32 bytes hex) env var.
+//! Encryption layer for `access_token` and `refresh_token` persisted in
+//! `withings_credentials.{access_token_enc, refresh_token_enc}` (`BYTEA`).
+//!
+//! Layout of each encrypted blob:
+//!
+//! ```text
+//! nonce (12 bytes) || ciphertext (variable) || authentication tag (16 bytes)
+//! ```
+//!
+//! The 32-byte master key is loaded from the `WITHINGS_TOKEN_KEY` env var
+//! (hex-encoded). Generate one with:
+//!
+//! ```sh
+//! openssl rand -hex 32
+//! ```
+//!
+//! In dev keep it under `.secrets/` (gitignored). In production the key lives
+//! in GCP Secret Manager and is injected as an env var into Cloud Run.
+
+use aes_gcm::{
+    Aes256Gcm, Nonce,
+    aead::{Aead, KeyInit},
+};
+use rand::RngCore;
+
+use crate::error::{WithingsError, WithingsResult};
+
+/// Length of the AES-256 master key, in bytes.
+pub const KEY_LEN: usize = 32;
+
+/// Length of the AES-GCM nonce, in bytes.
+const NONCE_LEN: usize = 12;
+
+/// AES-GCM authentication tag length, in bytes.
+const TAG_LEN: usize = 16;
+
+/// Minimum size of an encrypted blob: nonce + zero-length ciphertext + tag.
+const MIN_BLOB_LEN: usize = NONCE_LEN + TAG_LEN;
+
+/// Build an [`Aes256Gcm`] cipher from a raw 32-byte key.
+pub fn cipher_from_bytes(key: &[u8]) -> WithingsResult<Aes256Gcm> {
+    if key.len() != KEY_LEN {
+        return Err(WithingsError::Config(format!(
+            "expected {KEY_LEN}-byte master key, got {} bytes",
+            key.len()
+        )));
+    }
+    Aes256Gcm::new_from_slice(key)
+        .map_err(|e| WithingsError::Config(format!("invalid AES-256 key: {e}")))
+}
+
+/// Load the cipher from the `WITHINGS_TOKEN_KEY` env var
+/// (must be a 64-character hex string of 32 bytes).
+pub fn cipher_from_env() -> WithingsResult<Aes256Gcm> {
+    let hex_str = std::env::var("WITHINGS_TOKEN_KEY")
+        .map_err(|_| WithingsError::Config("WITHINGS_TOKEN_KEY env var is missing".into()))?;
+    let key = hex::decode(hex_str.trim())
+        .map_err(|e| WithingsError::Config(format!("WITHINGS_TOKEN_KEY is not valid hex: {e}")))?;
+    cipher_from_bytes(&key)
+}
+
+/// Encrypt `plaintext`, returning `nonce || ciphertext || tag`.
+///
+/// A fresh random nonce is generated for every call (AES-GCM IS NOT SAFE
+/// against nonce reuse with the same key — never reuse).
+pub fn encrypt(cipher: &Aes256Gcm, plaintext: &[u8]) -> WithingsResult<Vec<u8>> {
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| WithingsError::Encryption(e.to_string()))?;
+
+    let mut out = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+/// Decrypt a `nonce || ciphertext || tag` blob.
+///
+/// Returns [`WithingsError::Decryption`] if the blob is malformed, the
+/// authentication tag is invalid (tampering), or the key is wrong.
+pub fn decrypt(cipher: &Aes256Gcm, blob: &[u8]) -> WithingsResult<Vec<u8>> {
+    if blob.len() < MIN_BLOB_LEN {
+        return Err(WithingsError::Decryption(format!(
+            "ciphertext too short: {} bytes (minimum {MIN_BLOB_LEN})",
+            blob.len()
+        )));
+    }
+    let (nonce_bytes, rest) = blob.split_at(NONCE_LEN);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher
+        .decrypt(nonce, rest)
+        .map_err(|e| WithingsError::Decryption(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cipher() -> Aes256Gcm {
+        let key = [0x42u8; KEY_LEN];
+        cipher_from_bytes(&key).unwrap()
+    }
+
+    #[test]
+    fn roundtrip_recovers_plaintext() {
+        let cipher = test_cipher();
+        let plaintext = b"super-secret-access-token";
+        let blob = encrypt(&cipher, plaintext).unwrap();
+        let decrypted = decrypt(&cipher, &blob).unwrap();
+        assert_eq!(plaintext.as_ref(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn each_encrypt_uses_a_fresh_nonce() {
+        let cipher = test_cipher();
+        let plaintext = b"same plaintext bytes";
+        let blob1 = encrypt(&cipher, plaintext).unwrap();
+        let blob2 = encrypt(&cipher, plaintext).unwrap();
+        // AES-GCM with a fresh random nonce per call must produce
+        // different ciphertext for the same plaintext.
+        assert_ne!(blob1, blob2);
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_authentication() {
+        let cipher = test_cipher();
+        let mut blob = encrypt(&cipher, b"payload").unwrap();
+        // Flip a bit in the last byte (part of the auth tag).
+        *blob.last_mut().unwrap() ^= 0x01;
+        let result = decrypt(&cipher, &blob);
+        assert!(matches!(result, Err(WithingsError::Decryption(_))));
+    }
+
+    #[test]
+    fn truncated_blob_fails_with_clear_error() {
+        let cipher = test_cipher();
+        let short = vec![0u8; 10];
+        let result = decrypt(&cipher, &short);
+        assert!(matches!(result, Err(WithingsError::Decryption(_))));
+    }
+
+    #[test]
+    fn wrong_key_fails_authentication() {
+        let cipher_a = test_cipher();
+        let cipher_b = cipher_from_bytes(&[0xFFu8; KEY_LEN]).unwrap();
+        let blob = encrypt(&cipher_a, b"payload").unwrap();
+        let result = decrypt(&cipher_b, &blob);
+        assert!(matches!(result, Err(WithingsError::Decryption(_))));
+    }
+
+    #[test]
+    fn cipher_from_bytes_rejects_wrong_length() {
+        let too_short = vec![0u8; KEY_LEN - 1];
+        assert!(matches!(
+            cipher_from_bytes(&too_short),
+            Err(WithingsError::Config(_))
+        ));
+    }
+}

--- a/crates/withings/src/crypto.rs
+++ b/crates/withings/src/crypto.rs
@@ -1,0 +1,6 @@
+//! Token encryption (AES-256-GCM).
+//!
+//! Encryption layer for `access_token` and `refresh_token` stored in
+//! `withings_credentials.access_token_enc` / `refresh_token_enc` (BYTEA).
+//! Layout per encrypted blob: `nonce(12 bytes) || ciphertext || tag(16 bytes)`.
+//! Key is loaded from `WITHINGS_TOKEN_KEY` (32 bytes hex) env var.

--- a/crates/withings/src/error.rs
+++ b/crates/withings/src/error.rs
@@ -1,0 +1,4 @@
+//! Error types for Withings integration.
+//!
+//! `WithingsError` is the unified error for OAuth, HTTP, and crypto failures.
+//! Filled in during the implementation step of M4.

--- a/crates/withings/src/error.rs
+++ b/crates/withings/src/error.rs
@@ -1,4 +1,51 @@
-//! Error types for Withings integration.
+//! Error types for the Withings integration.
 //!
-//! `WithingsError` is the unified error for OAuth, HTTP, and crypto failures.
-//! Filled in during the implementation step of M4.
+//! `WithingsError` is the unified error returned by every fallible operation in
+//! this crate: HTTP calls, OAuth flow, token encryption, and response parsing.
+
+use thiserror::Error;
+
+pub type WithingsResult<T> = Result<T, WithingsError>;
+
+#[derive(Debug, Error)]
+pub enum WithingsError {
+    /// Network or HTTP-level failure (DNS, TLS, timeout, decoding the body, …).
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Withings returned `status != 0` in the response envelope.
+    /// See <https://developer.withings.com/api-reference#tag/return-status>.
+    #[error("Withings API error (status {status}): {message}")]
+    Api { status: i64, message: String },
+
+    /// OAuth-specific failure (invalid grant, expired refresh token, malformed
+    /// authorization response, …). Wraps a reason string from `oauth2` or our flow.
+    #[error("OAuth error: {0}")]
+    Oauth(String),
+
+    /// Authentication problem distinct from Oauth: e.g. no credentials stored
+    /// for the user, or stored access token expired and refresh failed.
+    #[error("authentication error: {0}")]
+    Auth(String),
+
+    /// Withings has temporarily rate-limited us. Caller should back off.
+    #[error("rate limited by Withings (retry after: {retry_after_secs:?}s)")]
+    RateLimit { retry_after_secs: Option<u64> },
+
+    /// Failed to decrypt a token blob (wrong key, tampered ciphertext, etc.).
+    #[error("token decryption failed: {0}")]
+    Decryption(String),
+
+    /// Failed to encrypt a token blob (e.g. RNG failure).
+    #[error("token encryption failed: {0}")]
+    Encryption(String),
+
+    /// Configuration is missing or invalid (e.g. `WITHINGS_TOKEN_KEY` env var).
+    #[error("invalid configuration: {0}")]
+    Config(String),
+
+    /// Withings returned a successful envelope but the body did not match the
+    /// expected shape (missing field, wrong type, …).
+    #[error("unexpected response shape: {0}")]
+    UnexpectedResponse(String),
+}

--- a/crates/withings/src/lib.rs
+++ b/crates/withings/src/lib.rs
@@ -13,5 +13,6 @@ pub mod error;
 pub mod oauth;
 pub mod types;
 
-// Re-exports (e.g. `WithingsError`) added during the implementation step,
-// once the types in the module skeletons exist.
+pub use client::WithingsClient;
+pub use error::{WithingsError, WithingsResult};
+pub use oauth::{TokenResponse, WithingsOauth};

--- a/crates/withings/src/lib.rs
+++ b/crates/withings/src/lib.rs
@@ -1,0 +1,17 @@
+//! Stadera Withings integration: OAuth 2.0, token management, and Health Mate API client.
+//!
+//! Provides:
+//! - [`oauth`]: OAuth2 authorization-code flow + refresh token handling
+//! - [`crypto`]: AES-256-GCM encryption for tokens at rest
+//! - [`client`]: Health Mate API HTTP client (measurements, etc.)
+//! - [`types`]: wire types for Withings API responses
+//! - [`error`]: error types for everything in this crate
+
+pub mod client;
+pub mod crypto;
+pub mod error;
+pub mod oauth;
+pub mod types;
+
+// Re-exports (e.g. `WithingsError`) added during the implementation step,
+// once the types in the module skeletons exist.

--- a/crates/withings/src/oauth.rs
+++ b/crates/withings/src/oauth.rs
@@ -1,0 +1,4 @@
+//! OAuth 2.0 flow for Withings: authorization code, token exchange, refresh.
+//!
+//! Withings uses standard RFC 6749 with the authorization-code grant.
+//! Refresh tokens have long expiry; access tokens expire in 3h (per docs).

--- a/crates/withings/src/oauth.rs
+++ b/crates/withings/src/oauth.rs
@@ -1,4 +1,155 @@
-//! OAuth 2.0 flow for Withings: authorization code, token exchange, refresh.
+//! OAuth 2.0 flow for Withings.
 //!
-//! Withings uses standard RFC 6749 with the authorization-code grant.
-//! Refresh tokens have long expiry; access tokens expire in 3h (per docs).
+//! Uses the `oauth2` crate for type-safe wrappers (`ClientId`, `ClientSecret`,
+//! `RedirectUrl`, `CsrfToken`) and authorization-URL building, but performs
+//! the actual token exchange and refresh via raw `reqwest`. The reason is
+//! that Withings wraps the token response in their `{status, body}` envelope
+//! (see [`crate::types::ApiEnvelope`]) instead of returning a plain RFC 6749
+//! body — bypassing `oauth2`'s built-in token handler avoids fighting the
+//! crate over a single-endpoint quirk.
+//!
+//! Standards-compliant OAuth providers (e.g. Google in M5) can use
+//! `oauth2`'s `request_async` end-to-end without this workaround.
+
+use oauth2::{AuthUrl, ClientId, ClientSecret, CsrfToken, RedirectUrl, TokenUrl};
+use serde::Deserialize;
+
+use crate::error::{WithingsError, WithingsResult};
+use crate::types::ApiEnvelope;
+
+const DEFAULT_AUTH_URL: &str = "https://account.withings.com/oauth2_user/authorize2";
+const DEFAULT_TOKEN_URL: &str = "https://wbsapi.withings.net/v2/oauth2";
+
+/// Body of a successful Withings token response.
+///
+/// Wrapped inside `ApiEnvelope` on the wire.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenResponse {
+    pub userid: String,
+    pub access_token: String,
+    pub refresh_token: String,
+    /// Lifetime of `access_token` in seconds. Withings docs: 10800 (3h).
+    pub expires_in: i64,
+    pub scope: String,
+    pub token_type: String,
+}
+
+/// OAuth 2.0 client for Withings.
+pub struct WithingsOauth {
+    client_id: ClientId,
+    client_secret: ClientSecret,
+    redirect_uri: RedirectUrl,
+    auth_url: AuthUrl,
+    token_url: TokenUrl,
+    http: reqwest::Client,
+}
+
+impl WithingsOauth {
+    /// Construct using Withings production endpoints.
+    pub fn new(
+        client_id: String,
+        client_secret: String,
+        redirect_uri: String,
+    ) -> WithingsResult<Self> {
+        Self::with_urls(
+            client_id,
+            client_secret,
+            redirect_uri,
+            DEFAULT_AUTH_URL.to_string(),
+            DEFAULT_TOKEN_URL.to_string(),
+        )
+    }
+
+    /// Construct with explicit URLs (used by tests with mock servers).
+    pub fn with_urls(
+        client_id: String,
+        client_secret: String,
+        redirect_uri: String,
+        auth_url: String,
+        token_url: String,
+    ) -> WithingsResult<Self> {
+        Ok(Self {
+            client_id: ClientId::new(client_id),
+            client_secret: ClientSecret::new(client_secret),
+            redirect_uri: RedirectUrl::new(redirect_uri)
+                .map_err(|e| WithingsError::Config(format!("invalid redirect_uri: {e}")))?,
+            auth_url: AuthUrl::new(auth_url)
+                .map_err(|e| WithingsError::Config(format!("invalid auth_url: {e}")))?,
+            token_url: TokenUrl::new(token_url)
+                .map_err(|e| WithingsError::Config(format!("invalid token_url: {e}")))?,
+            http: reqwest::Client::builder()
+                .build()
+                .map_err(WithingsError::Http)?,
+        })
+    }
+
+    /// Build the URL to send the user's browser to for consent.
+    /// Returns the URL and the random CSRF state — caller must store the
+    /// state and verify it matches the `state` param when the redirect arrives.
+    pub fn authorization_url(&self, scopes: &[&str]) -> (url::Url, CsrfToken) {
+        let csrf = CsrfToken::new_random();
+        let mut url =
+            url::Url::parse(self.auth_url.as_str()).expect("AUTH_URL validated at construction");
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", self.client_id.as_str())
+            .append_pair("scope", &scopes.join(","))
+            .append_pair("redirect_uri", self.redirect_uri.as_str())
+            .append_pair("state", csrf.secret());
+        (url, csrf)
+    }
+
+    /// Exchange an authorization `code` for tokens.
+    pub async fn exchange_code(&self, code: &str) -> WithingsResult<TokenResponse> {
+        let envelope: ApiEnvelope<TokenResponse> = self
+            .http
+            .post(self.token_url.as_str())
+            .form(&[
+                ("action", "requesttoken"),
+                ("grant_type", "authorization_code"),
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.secret()),
+                ("code", code),
+                ("redirect_uri", self.redirect_uri.as_str()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        unwrap_envelope(envelope)
+    }
+
+    /// Use a refresh token to obtain a fresh access token.
+    pub async fn refresh(&self, refresh_token: &str) -> WithingsResult<TokenResponse> {
+        let envelope: ApiEnvelope<TokenResponse> = self
+            .http
+            .post(self.token_url.as_str())
+            .form(&[
+                ("action", "requesttoken"),
+                ("grant_type", "refresh_token"),
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.secret()),
+                ("refresh_token", refresh_token),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        unwrap_envelope(envelope)
+    }
+}
+
+fn unwrap_envelope<T>(envelope: ApiEnvelope<T>) -> WithingsResult<T> {
+    if envelope.is_success() {
+        envelope
+            .body
+            .ok_or_else(|| WithingsError::UnexpectedResponse("status=0 but body is null".into()))
+    } else {
+        Err(WithingsError::Api {
+            status: envelope.status,
+            message: envelope.error.unwrap_or_default(),
+        })
+    }
+}

--- a/crates/withings/src/types.rs
+++ b/crates/withings/src/types.rs
@@ -1,0 +1,10 @@
+//! Wire types matching Withings Health Mate API responses.
+//!
+//! Withings wraps every response in:
+//!
+//! ```json
+//! { "status": 0, "body": { ... } }
+//! ```
+//!
+//! `status == 0` is success. Non-zero codes are documented errors
+//! (see <https://developer.withings.com/api-reference#tag/return-status>).

--- a/crates/withings/src/types.rs
+++ b/crates/withings/src/types.rs
@@ -1,10 +1,92 @@
 //! Wire types matching Withings Health Mate API responses.
 //!
-//! Withings wraps every response in:
+//! Withings wraps every response in an envelope:
 //!
 //! ```json
-//! { "status": 0, "body": { ... } }
+//! { "status": 0, "body": { ... }, "error": null }
 //! ```
 //!
-//! `status == 0` is success. Non-zero codes are documented errors
+//! `status == 0` is success; non-zero codes are documented errors
 //! (see <https://developer.withings.com/api-reference#tag/return-status>).
+//! Concrete body types are added per-endpoint as the client implementation grows.
+
+use serde::Deserialize;
+
+/// Generic envelope returned by every Withings endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ApiEnvelope<T> {
+    pub status: i64,
+    /// Present only when `status == 0`.
+    pub body: Option<T>,
+    /// Present only when `status != 0`.
+    pub error: Option<String>,
+}
+
+impl<T> ApiEnvelope<T> {
+    /// Returns true when the response represents a successful Withings call.
+    pub fn is_success(&self) -> bool {
+        self.status == 0
+    }
+}
+
+// ---- /measure?action=getmeas response ----------------------------------
+
+/// Body of `/measure?action=getmeas`.
+///
+/// Each `measuregrp` represents a single weighing event with one or more
+/// individual `measures` (weight, body fat percent, lean mass, …).
+#[derive(Debug, Deserialize)]
+pub struct GetMeasBody {
+    pub updatetime: i64,
+    #[serde(default)]
+    pub timezone: Option<String>,
+    pub measuregrps: Vec<MeasureGroup>,
+}
+
+/// A single weighing event.
+#[derive(Debug, Deserialize)]
+pub struct MeasureGroup {
+    pub grpid: i64,
+    /// Attribution: 0 = device, 1 = ambiguous, 2 = manual user creation, 4 = manual user creation during setup, 5 = measure created by app, 7 = measure auto-created
+    pub attrib: i32,
+    /// Unix timestamp (seconds) when the measurement was taken on the device.
+    pub date: i64,
+    /// Unix timestamp (seconds) when Withings server stored it.
+    #[serde(default)]
+    pub created: Option<i64>,
+    /// 1 = real measurement, 2 = user objective.
+    pub category: i32,
+    #[serde(default)]
+    pub deviceid: Option<String>,
+    pub measures: Vec<Measure>,
+    #[serde(default)]
+    pub comment: Option<String>,
+}
+
+/// One scalar measurement within a `MeasureGroup`.
+///
+/// The actual value is `value * 10^unit` (e.g. value=80000, unit=-3 → 80.000 kg).
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct Measure {
+    pub value: i64,
+    /// Measurement type. Subset relevant for Stadera:
+    /// 1 = weight (kg), 5 = lean mass (kg), 6 = body fat percent.
+    /// Full list: <https://developer.withings.com/api-reference#tag/measure>.
+    #[serde(rename = "type")]
+    pub measure_type: i32,
+    pub unit: i32,
+}
+
+impl Measure {
+    /// Decode `value * 10^unit` into a floating-point quantity.
+    pub fn as_f64(self) -> f64 {
+        (self.value as f64) * 10f64.powi(self.unit)
+    }
+}
+
+/// Withings measure type codes used by Stadera.
+pub mod measure_type {
+    pub const WEIGHT_KG: i32 = 1;
+    pub const LEAN_MASS_KG: i32 = 5;
+    pub const BODY_FAT_PERCENT: i32 = 6;
+}

--- a/crates/withings/tests/test_client.rs
+++ b/crates/withings/tests/test_client.rs
@@ -1,0 +1,131 @@
+use chrono::{TimeZone, Utc};
+use stadera_withings::types::measure_type;
+use stadera_withings::{WithingsClient, WithingsError};
+use wiremock::matchers::{bearer_token, body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client_pointing_to(server: &MockServer) -> WithingsClient {
+    WithingsClient::with_base_url(server.uri()).unwrap()
+}
+
+fn make_window() -> (chrono::DateTime<Utc>, chrono::DateTime<Utc>) {
+    let from = Utc.with_ymd_and_hms(2026, 4, 18, 0, 0, 0).unwrap();
+    let to = Utc.with_ymd_and_hms(2026, 4, 25, 0, 0, 0).unwrap();
+    (from, to)
+}
+
+#[tokio::test]
+async fn get_measurements_parses_envelope_and_groups() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/measure"))
+        .and(bearer_token("access-token-abc"))
+        .and(body_string_contains("action=getmeas"))
+        .and(body_string_contains("meastypes=1%2C5%2C6")) // url-encoded "1,5,6"
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 0,
+            "body": {
+                "updatetime": 1745539200,
+                "timezone": "Europe/Rome",
+                "measuregrps": [
+                    {
+                        "grpid": 100,
+                        "attrib": 0,
+                        "date": 1745452800,
+                        "created": 1745452801,
+                        "category": 1,
+                        "deviceid": "abc",
+                        "measures": [
+                            { "value": 80000, "type": 1, "unit": -3 },  // 80.000 kg
+                            { "value": 200, "type": 6, "unit": -1 },    // 20.0 %
+                            { "value": 64000, "type": 5, "unit": -3 }   // 64.000 kg
+                        ],
+                        "comment": null
+                    }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_pointing_to(&server);
+    let (from, to) = make_window();
+    let groups = client
+        .get_measurements("access-token-abc", from, to)
+        .await
+        .unwrap();
+
+    assert_eq!(groups.len(), 1);
+    let g = &groups[0];
+    assert_eq!(g.grpid, 100);
+    assert_eq!(g.measures.len(), 3);
+
+    // Find weight measure and verify decoded value.
+    let weight = g
+        .measures
+        .iter()
+        .find(|m| m.measure_type == measure_type::WEIGHT_KG)
+        .unwrap();
+    assert!((weight.as_f64() - 80.0).abs() < 1e-9);
+
+    let body_fat = g
+        .measures
+        .iter()
+        .find(|m| m.measure_type == measure_type::BODY_FAT_PERCENT)
+        .unwrap();
+    assert!((body_fat.as_f64() - 20.0).abs() < 1e-9);
+
+    let lean = g
+        .measures
+        .iter()
+        .find(|m| m.measure_type == measure_type::LEAN_MASS_KG)
+        .unwrap();
+    assert!((lean.as_f64() - 64.0).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn get_measurements_handles_empty_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/measure"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 0,
+            "body": {
+                "updatetime": 1745539200,
+                "measuregrps": []
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_pointing_to(&server);
+    let (from, to) = make_window();
+    let groups = client.get_measurements("any", from, to).await.unwrap();
+    assert!(groups.is_empty());
+}
+
+#[tokio::test]
+async fn get_measurements_maps_api_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/measure"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 401,
+            "error": "Invalid Token"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_pointing_to(&server);
+    let (from, to) = make_window();
+    let result = client.get_measurements("expired-token", from, to).await;
+
+    match result {
+        Err(WithingsError::Api { status, message }) => {
+            assert_eq!(status, 401);
+            assert_eq!(message, "Invalid Token");
+        }
+        other => panic!("expected WithingsError::Api, got {other:?}"),
+    }
+}

--- a/crates/withings/tests/test_oauth.rs
+++ b/crates/withings/tests/test_oauth.rs
@@ -1,0 +1,159 @@
+use stadera_withings::{WithingsError, WithingsOauth};
+use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn oauth_pointing_to(server: &MockServer) -> WithingsOauth {
+    WithingsOauth::with_urls(
+        "test-client-id".to_string(),
+        "test-client-secret".to_string(),
+        "http://localhost:7878/callback".to_string(),
+        format!("{}/oauth2_user/authorize2", server.uri()),
+        format!("{}/v2/oauth2", server.uri()),
+    )
+    .unwrap()
+}
+
+#[test]
+fn authorization_url_contains_expected_params() {
+    // Use a dummy server URI; we don't hit the network in this test.
+    let oauth = WithingsOauth::with_urls(
+        "test-client-id".to_string(),
+        "test-secret".to_string(),
+        "http://localhost:7878/callback".to_string(),
+        "https://example.com/authorize".to_string(),
+        "https://example.com/token".to_string(),
+    )
+    .unwrap();
+
+    let (url, csrf) = oauth.authorization_url(&["user.metrics", "user.info"]);
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    let get = |k: &str| {
+        pairs
+            .iter()
+            .find(|(key, _)| key == k)
+            .map(|(_, v)| v.clone())
+    };
+
+    assert_eq!(get("response_type").as_deref(), Some("code"));
+    assert_eq!(get("client_id").as_deref(), Some("test-client-id"));
+    assert_eq!(
+        get("scope").as_deref(),
+        Some("user.metrics,user.info"),
+        "scopes joined with comma per Withings convention"
+    );
+    assert_eq!(
+        get("redirect_uri").as_deref(),
+        Some("http://localhost:7878/callback")
+    );
+    assert_eq!(get("state").as_deref(), Some(csrf.secret().as_str()));
+}
+
+#[tokio::test]
+async fn exchange_code_returns_token_on_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/oauth2"))
+        .and(header("content-type", "application/x-www-form-urlencoded"))
+        .and(body_string_contains("action=requesttoken"))
+        .and(body_string_contains("grant_type=authorization_code"))
+        .and(body_string_contains("code=auth-code-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 0,
+            "body": {
+                "userid": "12345",
+                "access_token": "access-abc",
+                "refresh_token": "refresh-xyz",
+                "expires_in": 10800,
+                "scope": "user.metrics",
+                "token_type": "Bearer"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let oauth = oauth_pointing_to(&server);
+    let token = oauth.exchange_code("auth-code-xyz").await.unwrap();
+
+    assert_eq!(token.userid, "12345");
+    assert_eq!(token.access_token, "access-abc");
+    assert_eq!(token.refresh_token, "refresh-xyz");
+    assert_eq!(token.expires_in, 10800);
+    assert_eq!(token.scope, "user.metrics");
+}
+
+#[tokio::test]
+async fn exchange_code_maps_non_zero_status_to_api_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/oauth2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 503,
+            "error": "invalid_grant"
+        })))
+        .mount(&server)
+        .await;
+
+    let oauth = oauth_pointing_to(&server);
+    let result = oauth.exchange_code("bad-code").await;
+
+    match result {
+        Err(WithingsError::Api { status, message }) => {
+            assert_eq!(status, 503);
+            assert_eq!(message, "invalid_grant");
+        }
+        other => panic!("expected WithingsError::Api, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn refresh_uses_refresh_token_grant() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/oauth2"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains("refresh_token=old-refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 0,
+            "body": {
+                "userid": "12345",
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 10800,
+                "scope": "user.metrics",
+                "token_type": "Bearer"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let oauth = oauth_pointing_to(&server);
+    let token = oauth.refresh("old-refresh").await.unwrap();
+
+    assert_eq!(token.access_token, "new-access");
+    assert_eq!(token.refresh_token, "new-refresh");
+}
+
+#[tokio::test]
+async fn missing_body_on_success_is_unexpected_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/oauth2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 0
+        })))
+        .mount(&server)
+        .await;
+
+    let oauth = oauth_pointing_to(&server);
+    let result = oauth.exchange_code("any").await;
+
+    assert!(matches!(result, Err(WithingsError::UnexpectedResponse(_))));
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,9 @@
   "separate-pull-requests": false,
   "include-component-in-tag": true,
   "packages": {
-    "crates/api":     { "package-name": "stadera-api",     "component": "api"     },
-    "crates/domain":  { "package-name": "stadera-domain",  "component": "domain"  },
-    "crates/storage": { "package-name": "stadera-storage", "component": "storage" }
+    "crates/api":      { "package-name": "stadera-api",      "component": "api"      },
+    "crates/domain":   { "package-name": "stadera-domain",   "component": "domain"   },
+    "crates/storage":  { "package-name": "stadera-storage",  "component": "storage"  },
+    "crates/withings": { "package-name": "stadera-withings", "component": "withings" }
   }
 }

--- a/release-please-manifest.json
+++ b/release-please-manifest.json
@@ -1,5 +1,6 @@
 {
-  "crates/api":     "0.1.0",
-  "crates/domain":  "0.1.0",
-  "crates/storage": "0.1.0"
+  "crates/api":      "0.1.0",
+  "crates/domain":   "0.1.0",
+  "crates/storage":  "0.1.0",
+  "crates/withings": "0.1.0"
 }


### PR DESCRIPTION
## Summary

Introduces \`stadera-withings\`: OAuth2 flow + Health Mate API client +
AES-256-GCM token encryption, plus a \`pair\` CLI binary for the first-time
OAuth pairing. Also adds an idempotency UNIQUE constraint to \`measurements\`
in preparation for the sync job (M4 PR B).

## Motivation / Context

- Milestone: M4 (first of two PRs)
- This PR: library + manual pairing tool. Next PR (\`feat/sync-job\`):
  \`crates/jobs\` cron binary that uses storage + withings end-to-end.

## Changes

### \`crates/withings\` (new crate)
- \`error.rs\`: \`WithingsError\` with variants for HTTP / API status / OAuth /
  rate limit / encryption / decryption / config / unexpected response.
- \`types.rs\`: \`ApiEnvelope<T>\` for Withings' \`{status, body, error}\` wrapper,
  plus \`GetMeasBody\`, \`MeasureGroup\`, \`Measure\` and \`measure_type\` constants.
- \`crypto.rs\`: AES-256-GCM with random nonce per encrypt; key from
  \`WITHINGS_TOKEN_KEY\` (32-byte hex). 6 unit tests including tamper detection.
- \`oauth.rs\`: \`WithingsOauth\` — hybrid approach using \`oauth2\` crate types
  (\`ClientId\`, \`ClientSecret\`, \`RedirectUrl\`, \`CsrfToken\`) but raw \`reqwest\`
  POST for token exchange/refresh because Withings wraps responses in their
  envelope (non-standard RFC 6749).
- \`client.rs\`: \`WithingsClient\` with \`get_measurements(access_token, from, to)\`.
- \`bin/pair.rs\`: one-shot CLI that opens auth URL, listens on
  \`localhost:7878\`, validates CSRF state, exchanges code, encrypts tokens,
  upserts via storage. \`--user-email\` required, \`--user-name\` optional.
- 8 wiremock integration tests for oauth + client.

### Storage idempotency
- Migration \`20260425090000_measurement_idempotency.sql\`: UNIQUE constraint
  on \`measurements(user_id, taken_at, source)\` so the future sync can use
  \`ON CONFLICT DO NOTHING\` and be safely retryable.

### Workspace
- Added deps: \`reqwest\` (rustls), \`oauth2 5\`, \`aes-gcm 0.10\`, \`rand 0.9\`,
  \`hex 0.4\`, \`url 2\`, \`clap 4\` (derive), \`wiremock 0.6\` (dev).
- \`crates/withings\` registered in workspace + release-please.

## Test plan
- [x] cargo fmt / clippy -D warnings / test --all (all green locally)
- [x] 14 new tests (6 crypto unit + 5 oauth wiremock + 3 client wiremock)
- [x] make db-reset applies both migrations cleanly
- [ ] manual: real pairing against Withings sandbox/prod (run \`pair\` and verify
      tokens land in \`withings_credentials\`)

## Notes for reviewer
- \`pair\` binary is a one-shot setup tool — not part of the cron pipeline,
  not exposed by the API. Safe to refactor freely without breaking anything else.
- \`oauth2\` crate is used for type-safe wrappers only; the actual token POST is
  raw \`reqwest\` because Withings non-standard envelope made the round-trip via
  \`oauth2\`'s built-in token handler more boilerplate than the bypass.
- Withings token key is 32-byte hex; generate with \`openssl rand -hex 32\`.
  Production key will live in GCP Secret Manager (M7).
- Migration is forward-only.