### PR TITLE
feat(jobs): implement Withings sync job and related infrastructure

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -72,7 +72,7 @@ stadera/
 | M1 | Foundations | ✅ Done | Workspace, CI, release-please, conventional commits |
 | M2 | Domain core | ✅ Done | Merged via PR #2 (squashed into `1507c18`). Domain blockers resolved. Follow-ups tracked in `reviews/pr-2.md` |
 | M3 | Storage | ✅ Done | Both PRs merged: scaffold (#3) and repositories+tests (#5). Closed `1507c18..4730651` |
-| M4 | Withings integration | ⏳ In progress | OAuth2 flow + Health Mate API client + token refresh (`crates/withings`) and sync cron binary (`crates/jobs`). Multi-tenant DB schema ready since M3 |
+| M4 | Withings integration | ⏳ In progress | PR A `feat/withings-scaffold` merged (#6): OAuth2 + API client + crypto + pair binary. PR B `feat/sync-job` open: `crates/jobs` cron binary that syncs measurements end-to-end |
 | M5 | API + Frontend | 📋 Planned | axum endpoints (`/today`, `/trend`, `/history`), OAuth Google auth middleware, utoipa/Swagger. `stadera-web` repo scaffolded |
 | M6 | Notifications | 📋 Planned | Pushover daily job, Resend weekly digest (Apple-weekly-summary style) |
 | M7 | Cloud deploy | 📋 Planned | Terraform, GitHub Actions deploy, Dockerfile multi-stage, Vercel for frontend |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "stadera-jobs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "dotenvy",
+ "sqlx",
+ "stadera-domain",
+ "stadera-storage",
+ "stadera-withings",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "stadera-storage"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/api", "crates/domain", "crates/storage", "crates/withings"]
+members = ["crates/api", "crates/domain", "crates/jobs", "crates/storage", "crates/withings"]
 
 [workspace.package]
 edition = "2024"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: help db-up db-down db-reset db-migrate db-psql check
+.PHONY: help db-up db-down db-reset db-migrate db-psql check pair sync
+
+# Default user-email for pair / sync. Override with: make pair USER_EMAIL=alice@example.com
+USER_EMAIL ?= michelebellitti78@gmail.com
 
 help:
 	@echo "Dev targets:"
@@ -7,6 +10,8 @@ help:
 	@echo "  db-reset     Destroy volume and recreate + migrate"
 	@echo "  db-migrate   Run sqlx migrations against local DB"
 	@echo "  db-psql      Open psql shell into local DB"
+	@echo "  pair         Run first-time Withings OAuth pairing (USER_EMAIL=...)"
+	@echo "  sync         Run a one-shot Withings sync (USER_EMAIL=...)"
 	@echo "  check        cargo fmt + clippy + test"
 
 db-up:
@@ -28,6 +33,12 @@ db-migrate:
 
 db-psql:
 	docker compose exec postgres psql -U stadera -d stadera
+
+pair:
+	cargo run -p stadera-withings --bin pair -- --user-email $(USER_EMAIL)
+
+sync:
+	cargo run -p stadera-jobs -- sync --user-email $(USER_EMAIL)
 
 check:
 	cargo fmt --all -- --check

--- a/crates/jobs/Cargo.toml
+++ b/crates/jobs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stadera-jobs"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+stadera-domain = { path = "../domain" }
+stadera-storage = { path = "../storage" }
+stadera-withings = { path = "../withings" }
+sqlx.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+clap.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+dotenvy.workspace = true
+uuid.workspace = true

--- a/crates/jobs/src/main.rs
+++ b/crates/jobs/src/main.rs
@@ -1,0 +1,55 @@
+//! Stadera cron / job entry point.
+//!
+//! Single binary with subcommands so the same image can run different jobs
+//! (Cloud Run Jobs invokes one subcommand per scheduler trigger).
+//!
+//! Available subcommands:
+//! - `sync` — pull recent measurements from Withings and persist them.
+//! - (future) `digest` — weekly Resend email digest (M6).
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
+
+mod sync;
+
+#[derive(Parser)]
+#[command(name = "stadera-jobs", version, about = "Stadera cron jobs")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Pull recent measurements from Withings into the database.
+    Sync {
+        /// Email of the user whose measurements to sync.
+        #[arg(long)]
+        user_email: String,
+        /// Sync window in days (defaults to 7).
+        #[arg(long, default_value_t = 7)]
+        window_days: i64,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Auto-load `.env` for local runs; no-op in production where env vars
+    // come from Cloud Run / Secret Manager.
+    let _ = dotenvy::dotenv();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Sync {
+            user_email,
+            window_days,
+        } => sync::run(&user_email, window_days).await,
+    }
+}

--- a/crates/jobs/src/sync.rs
+++ b/crates/jobs/src/sync.rs
@@ -1,0 +1,284 @@
+//! Withings → Stadera sync job.
+//!
+//! Steps:
+//! 1. Connect Postgres.
+//! 2. Look up the user by email; refuse if missing.
+//! 3. Load encrypted Withings credentials; refuse if missing (run `pair` first).
+//! 4. Decrypt access + refresh tokens.
+//! 5. If access token is within 60s of expiry, refresh it and persist.
+//! 6. Call Withings `getmeas` for the window `[now - window_days, now]`.
+//! 7. Map measure groups → domain `Measurement`. Skip groups without a weight.
+//! 8. `insert_or_skip_batch` with the UNIQUE constraint on
+//!    `(user_id, taken_at, source)` for idempotency.
+//! 9. Log totals (`fetched`, `inserted`, `skipped`).
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use sqlx::PgPool;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use stadera_domain::{BodyFatPercent, LeanMass, Measurement, Source, Weight};
+use stadera_storage::{StorageContext, WithingsCredentials};
+use stadera_withings::WithingsClient;
+use stadera_withings::crypto::{self, Cipher};
+use stadera_withings::oauth::{TokenResponse, WithingsOauth};
+use stadera_withings::types::{MeasureGroup, measure_type};
+
+/// Refresh tokens that expire within this window.
+const REFRESH_BUFFER: Duration = Duration::seconds(60);
+
+/// Entry point invoked from `main`.
+pub async fn run(user_email: &str, window_days: i64) -> Result<()> {
+    if window_days < 1 {
+        anyhow::bail!("--window-days must be >= 1, got {window_days}");
+    }
+
+    let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL env var is required")?;
+    let pool = PgPool::connect(&database_url)
+        .await
+        .context("failed to connect to Postgres")?;
+    let storage = StorageContext::new(pool);
+
+    let user = storage
+        .users()
+        .get_by_email(user_email)
+        .await?
+        .with_context(|| format!("user not found for email: {user_email}"))?;
+    info!(user_id = %user.id, email = %user.email, "starting Withings sync");
+
+    let creds = storage
+        .withings_credentials()
+        .get(user.id)
+        .await?
+        .context("no Withings credentials stored for this user — run `pair` first")?;
+
+    let cipher = crypto::cipher_from_env()
+        .context("failed to load encryption cipher (WITHINGS_TOKEN_KEY)")?;
+
+    let access_token = decrypt_to_string(&cipher, &creds.access_token_enc, "access_token")?;
+    let refresh_token = decrypt_to_string(&cipher, &creds.refresh_token_enc, "refresh_token")?;
+
+    // Refresh proactively if near expiry.
+    let access_token = if needs_refresh(creds.expires_at) {
+        info!(
+            expires_at = %creds.expires_at,
+            "access token within {}s of expiry, refreshing",
+            REFRESH_BUFFER.num_seconds(),
+        );
+        refresh_and_persist(&storage, &cipher, user.id, &refresh_token).await?
+    } else {
+        access_token
+    };
+
+    let to = Utc::now();
+    let from = to - Duration::days(window_days);
+
+    let client = WithingsClient::new().context("failed to build Withings HTTP client")?;
+    let groups = client
+        .get_measurements(&access_token, from, to)
+        .await
+        .context("failed to fetch measurements from Withings")?;
+    info!(
+        groups = groups.len(),
+        from = %from, to = %to,
+        "fetched measure groups from Withings",
+    );
+
+    let measurements: Vec<Measurement> = groups.iter().filter_map(map_group).collect();
+    let mapped = measurements.len();
+    let dropped = groups.len() - mapped;
+    if dropped > 0 {
+        warn!(dropped, "skipped groups without a usable weight measure");
+    }
+
+    let inserted = storage
+        .measurements()
+        .insert_or_skip_batch(user.id, &measurements)
+        .await?;
+    let skipped = mapped.saturating_sub(inserted);
+
+    info!(
+        groups = groups.len(),
+        mapped, inserted, skipped, "sync complete",
+    );
+    Ok(())
+}
+
+fn needs_refresh(expires_at: DateTime<Utc>) -> bool {
+    expires_at - REFRESH_BUFFER <= Utc::now()
+}
+
+fn decrypt_to_string(cipher: &Cipher, blob: &[u8], label: &'static str) -> Result<String> {
+    let bytes =
+        crypto::decrypt(cipher, blob).with_context(|| format!("failed to decrypt {label}"))?;
+    String::from_utf8(bytes).with_context(|| format!("{label} is not valid UTF-8"))
+}
+
+async fn refresh_and_persist(
+    storage: &StorageContext,
+    cipher: &Cipher,
+    user_id: Uuid,
+    refresh_token: &str,
+) -> Result<String> {
+    let client_id = std::env::var("WITHINGS_CLIENT_ID")
+        .context("WITHINGS_CLIENT_ID env var is required for token refresh")?;
+    let client_secret = std::env::var("WITHINGS_CLIENT_SECRET")
+        .context("WITHINGS_CLIENT_SECRET env var is required for token refresh")?;
+    // The redirect_uri is not actually used by the refresh request, but
+    // `WithingsOauth::new` requires a syntactically valid one.
+    let redirect_uri = "http://localhost:7878/callback".to_string();
+
+    let oauth = WithingsOauth::new(client_id, client_secret, redirect_uri)
+        .context("failed to build WithingsOauth for refresh")?;
+
+    let new_tokens: TokenResponse = oauth
+        .refresh(refresh_token)
+        .await
+        .context("Withings refused refresh_token (re-pair required?)")?;
+
+    let access_enc = crypto::encrypt(cipher, new_tokens.access_token.as_bytes())
+        .context("failed to encrypt new access_token")?;
+    let refresh_enc = crypto::encrypt(cipher, new_tokens.refresh_token.as_bytes())
+        .context("failed to encrypt new refresh_token")?;
+    let expires_at = Utc::now() + Duration::seconds(new_tokens.expires_in);
+
+    let updated = WithingsCredentials {
+        user_id,
+        access_token_enc: access_enc,
+        refresh_token_enc: refresh_enc,
+        expires_at,
+        scope: new_tokens.scope,
+    };
+    storage.withings_credentials().upsert(&updated).await?;
+    info!("refreshed and persisted Withings tokens");
+
+    Ok(new_tokens.access_token)
+}
+
+/// Decode a Withings `MeasureGroup` into a domain `Measurement`.
+///
+/// Returns `None` if:
+/// - the group has no weight measurement (we cannot construct a `Measurement`),
+/// - the weight value is out of the domain range,
+/// - the timestamp is outside i64 range (impossible in practice).
+///
+/// Body-fat-percent and lean-mass are optional; if their values are out of
+/// range we just drop them rather than failing the whole group.
+fn map_group(g: &MeasureGroup) -> Option<Measurement> {
+    let weight = find_value(g, measure_type::WEIGHT_KG).and_then(|v| Weight::new(v).ok())?;
+    let taken_at = DateTime::<Utc>::from_timestamp(g.date, 0)?;
+
+    let body_fat =
+        find_value(g, measure_type::BODY_FAT_PERCENT).and_then(|v| BodyFatPercent::new(v).ok());
+    let lean_mass = find_value(g, measure_type::LEAN_MASS_KG).and_then(|v| LeanMass::new(v).ok());
+
+    Some(Measurement::new(
+        taken_at,
+        weight,
+        body_fat,
+        lean_mass,
+        Source::Withings,
+    ))
+}
+
+fn find_value(g: &MeasureGroup, kind: i32) -> Option<f64> {
+    g.measures
+        .iter()
+        .find(|m| m.measure_type == kind)
+        .map(|m| m.as_f64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use stadera_withings::types::Measure;
+
+    fn measure(measure_type: i32, value: i64, unit: i32) -> Measure {
+        Measure {
+            value,
+            measure_type,
+            unit,
+        }
+    }
+
+    fn group(date: i64, measures: Vec<Measure>) -> MeasureGroup {
+        MeasureGroup {
+            grpid: 1,
+            attrib: 0,
+            date,
+            created: None,
+            category: 1,
+            deviceid: None,
+            measures,
+            comment: None,
+        }
+    }
+
+    #[test]
+    fn map_group_with_full_measures() {
+        let g = group(
+            1745452800,
+            vec![
+                measure(measure_type::WEIGHT_KG, 80000, -3),      // 80 kg
+                measure(measure_type::BODY_FAT_PERCENT, 200, -1), // 20.0%
+                measure(measure_type::LEAN_MASS_KG, 64000, -3),   // 64 kg
+            ],
+        );
+        let m = map_group(&g).unwrap();
+        assert_eq!(m.weight.value(), 80.0);
+        assert_eq!(m.body_fat.unwrap().value(), 20.0);
+        assert_eq!(m.lean_mass.unwrap().value(), 64.0);
+        assert_eq!(m.source, Source::Withings);
+        assert_eq!(
+            m.taken_at,
+            Utc.timestamp_opt(1745452800, 0).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn map_group_without_weight_returns_none() {
+        let g = group(
+            1745452800,
+            vec![
+                measure(measure_type::BODY_FAT_PERCENT, 200, -1), // only body fat, no weight
+            ],
+        );
+        assert!(map_group(&g).is_none());
+    }
+
+    #[test]
+    fn map_group_drops_out_of_range_optionals_but_keeps_weight() {
+        let g = group(
+            1745452800,
+            vec![
+                measure(measure_type::WEIGHT_KG, 80000, -3),      // valid
+                measure(measure_type::BODY_FAT_PERCENT, 1000, 0), // 1000% — out of range, drop
+            ],
+        );
+        let m = map_group(&g).unwrap();
+        assert_eq!(m.weight.value(), 80.0);
+        assert!(m.body_fat.is_none(), "out-of-range body fat dropped");
+    }
+
+    #[test]
+    fn needs_refresh_inside_buffer() {
+        // expires 30s in the future → within 60s buffer → refresh
+        let expires = Utc::now() + Duration::seconds(30);
+        assert!(needs_refresh(expires));
+    }
+
+    #[test]
+    fn needs_refresh_well_in_the_future() {
+        // expires in 1h → no refresh
+        let expires = Utc::now() + Duration::hours(1);
+        assert!(!needs_refresh(expires));
+    }
+
+    #[test]
+    fn needs_refresh_already_expired() {
+        let expires = Utc::now() - Duration::seconds(10);
+        assert!(needs_refresh(expires));
+    }
+}

--- a/crates/storage/src/repositories/measurement.rs
+++ b/crates/storage/src/repositories/measurement.rs
@@ -75,6 +75,47 @@ impl<'a> PgMeasurementRepository<'a> {
         Ok(ids)
     }
 
+    /// Idempotent batch insert: rows already present (matched on the UNIQUE
+    /// `(user_id, taken_at, source)` key) are silently skipped. Returns the
+    /// number of rows actually inserted (`total - duplicates`). Wrapped in a
+    /// transaction for the same atomicity guarantee as [`Self::insert_batch`].
+    ///
+    /// This is the method the Withings sync job uses: re-running the same
+    /// 7-day window leaves the database unchanged for already-known
+    /// measurements, while picking up genuinely new ones.
+    #[instrument(skip(self, measurements))]
+    pub async fn insert_or_skip_batch(
+        &self,
+        user_id: Uuid,
+        measurements: &[Measurement],
+    ) -> StorageResult<usize> {
+        let mut tx = self.pool.begin().await?;
+        let mut inserted = 0usize;
+        for m in measurements {
+            let id = Uuid::now_v7();
+            let result = sqlx::query!(
+                r#"
+                INSERT INTO measurements
+                    (id, user_id, taken_at, weight_kg, body_fat_percent, lean_mass_kg, source)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT (user_id, taken_at, source) DO NOTHING
+                "#,
+                id,
+                user_id,
+                m.taken_at,
+                m.weight.value(),
+                m.body_fat.map(|bf| bf.value()),
+                m.lean_mass.map(|lm| lm.value()),
+                source_to_str(m.source),
+            )
+            .execute(&mut *tx)
+            .await?;
+            inserted += result.rows_affected() as usize;
+        }
+        tx.commit().await?;
+        Ok(inserted)
+    }
+
     #[instrument(skip(self))]
     pub async fn get_by_id(&self, id: Uuid) -> StorageResult<Option<Measurement>> {
         let row = sqlx::query_as!(

--- a/crates/storage/tests/test_measurement_repo.rs
+++ b/crates/storage/tests/test_measurement_repo.rs
@@ -241,3 +241,88 @@ async fn insert_batch_rolls_back_on_failure(pool: PgPool) -> sqlx::Result<()> {
     );
     Ok(())
 }
+
+#[sqlx::test]
+async fn insert_or_skip_batch_inserts_new(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    let measurements: Vec<Measurement> = (20u32..=22).map(sample_measurement).collect();
+    let inserted = ctx
+        .measurements()
+        .insert_or_skip_batch(user_id, &measurements)
+        .await
+        .unwrap();
+
+    assert_eq!(inserted, 3, "all three rows are new");
+    let all = ctx
+        .measurements()
+        .list_for_user_latest(user_id, 10)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn insert_or_skip_batch_skips_duplicates(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    let measurements: Vec<Measurement> = (20u32..=22).map(sample_measurement).collect();
+
+    // First call: 3 inserts.
+    let first = ctx
+        .measurements()
+        .insert_or_skip_batch(user_id, &measurements)
+        .await
+        .unwrap();
+    assert_eq!(first, 3);
+
+    // Second call with the exact same payload: zero inserts (all conflicts).
+    let second = ctx
+        .measurements()
+        .insert_or_skip_batch(user_id, &measurements)
+        .await
+        .unwrap();
+    assert_eq!(second, 0);
+
+    // Total rows in DB: still 3, not 6.
+    let all = ctx
+        .measurements()
+        .list_for_user_latest(user_id, 100)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+    Ok(())
+}
+
+#[sqlx::test]
+async fn insert_or_skip_batch_mixes_new_and_existing(pool: PgPool) -> sqlx::Result<()> {
+    let ctx = StorageContext::new(pool);
+    let user_id = create_test_user(&ctx).await;
+
+    // Pre-populate with days 20..=21.
+    let pre: Vec<Measurement> = (20u32..=21).map(sample_measurement).collect();
+    ctx.measurements()
+        .insert_or_skip_batch(user_id, &pre)
+        .await
+        .unwrap();
+
+    // Now feed days 20..=23: days 20-21 are duplicates, days 22-23 are new.
+    let mixed: Vec<Measurement> = (20u32..=23).map(sample_measurement).collect();
+    let inserted = ctx
+        .measurements()
+        .insert_or_skip_batch(user_id, &mixed)
+        .await
+        .unwrap();
+    assert_eq!(inserted, 2, "only the two new days are inserted");
+
+    let all = ctx
+        .measurements()
+        .list_for_user_latest(user_id, 100)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 4);
+    Ok(())
+}

--- a/crates/withings/src/crypto.rs
+++ b/crates/withings/src/crypto.rs
@@ -25,6 +25,10 @@ use aes_gcm::{
 };
 use rand::RngCore;
 
+// Re-export so downstream crates (e.g. `stadera-jobs`) can pass cipher
+// references around without taking a direct dependency on `aes-gcm`.
+pub use aes_gcm::Aes256Gcm as Cipher;
+
 use crate::error::{WithingsError, WithingsResult};
 
 /// Length of the AES-256 master key, in bytes.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     "crates/api":      { "package-name": "stadera-api",      "component": "api"      },
     "crates/domain":   { "package-name": "stadera-domain",   "component": "domain"   },
+    "crates/jobs":     { "package-name": "stadera-jobs",     "component": "jobs"     },
     "crates/storage":  { "package-name": "stadera-storage",  "component": "storage"  },
     "crates/withings": { "package-name": "stadera-withings", "component": "withings" }
   }

--- a/release-please-manifest.json
+++ b/release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "crates/api":      "0.1.0",
   "crates/domain":   "0.1.0",
+  "crates/jobs":     "0.1.0",
   "crates/storage":  "0.1.0",
   "crates/withings": "0.1.0"
 }


### PR DESCRIPTION
## Summary
Closes M4. Introduces `crates/jobs`, a cron-friendly binary with a `sync` subcommand that pulls
recent Withings measurements end-to-end: decrypt tokens → refresh if near expiry → fetch via
`WithingsClient::get_measurements` → map `MeasureGroup` → `Measurement` → `insert_or_skip_batch`.

## Motivation / Context
- Milestone: M4 (final PR — closes the integration)
- Cloud Run Jobs (M7) will invoke `stadera-jobs sync --user-email …` daily via Cloud Scheduler.

## Changes
- `crates/jobs` new binary with clap subcommands. `sync` is the only one for now; `digest` lands in M6.
- `PgMeasurementRepository::insert_or_skip_batch` uses `ON CONFLICT DO NOTHING` on the UNIQUE key
  added in PR #6, returning the count of actually-inserted rows.
- Token refresh strategy: proactive 60s before `expires_at`; new tokens persisted atomically via `upsert`.
- `MeasureGroup → Measurement` mapping: Withings `value * 10^unit` decoded back to `f64`,
  validated through domain newtypes; groups without a weight measure are dropped.
- `make sync` / `make pair` targets, both with `USER_EMAIL=...` override.

## Test plan
- [x] cargo fmt / clippy -D warnings / test --all (all green; 108 tests)
- [x] 6 sync unit tests (`map_group` happy / no-weight / out-of-range; `needs_refresh` boundary cases)
- [x] 3 idempotency integration tests (insert / skip-duplicates / mixed)
- [ ] Manual: `make sync` populates DB; running it twice shows `inserted=0 skipped=N` second time.

## Notes for reviewer
- `crypto::Cipher` is a re-export of `aes_gcm::Aes256Gcm` so `stadera-jobs` doesn't need a direct
  `aes-gcm` dependency.
- Token refresh re-uses `WithingsOauth::refresh`; the `redirect_uri` passed is unused by Withings
  for the refresh grant (only required to satisfy `WithingsOauth::new`).
- M6 (notifications) and M7 (deploy) will share this binary: digest as a new subcommand,
  Dockerfile + Cloud Run Job + Scheduler.