### PR TITLE
feat: Cloud Run deploy — Dockerfile + GitHub Actions OIDC

### DIFF
--- a/.claude/docs/deploy-gcp-walkthrough.md
+++ b/.claude/docs/deploy-gcp-walkthrough.md
@@ -1,0 +1,199 @@
+# Backend Cloud Run deploy — GCP walkthrough
+
+Step-by-step explanation of the `gcloud` commands in
+[the README's Deploy section](../../README.md#deploy).
+
+If you've never set up Workload Identity Federation before,
+**read [stadera-web's walkthrough](https://github.com/MicheleBellitti/stadera-web/blob/main/.claude/docs/deploy-gcp-walkthrough.md)
+first** — it covers the OIDC ↔ STS ↔ IAM ↔ SA flow in depth, the
+mental model of pools and providers, and the diagnostics for the
+common failure modes. This doc only covers what's *different* for the
+backend.
+
+## What's reused from the frontend setup
+
+After running the frontend walkthrough, the following GCP resources
+already exist:
+
+| Resource | Name | Reuse for backend? |
+|---|---|---|
+| Artifact Registry repo | `stadera` (in `europe-west1`) | ✅ same repo, different image name (`stadera-api` vs `stadera-web`) |
+| Workload Identity Pool | `github-pool` | ✅ same pool, new provider inside it |
+
+What's *new* for the backend:
+
+| Resource | Name | Why |
+|---|---|---|
+| Service account | `stadera-api-deployer` | separate identity per service, so blast radius of a compromised CI is limited to one repo |
+| WIF Provider | `stadera-api-provider` | scoped to `MicheleBellitti/Stadera` (the existing `github-provider` is locked to `MicheleBellitti/stadera-web`) |
+| Cloud Run Service | `stadera-api` | the actual runtime |
+
+## Why a new provider per repo
+
+You *could* update the existing provider's `attribute-condition` to
+allow both repos, e.g.:
+
+```cel
+assertion.repository in ['MicheleBellitti/stadera-web', 'MicheleBellitti/Stadera']
+```
+
+But that's a single point of failure: if you tighten or break it for
+one repo, you break the other. Two providers cost nothing (no quota,
+no money) and let each repo's deploy auth be debugged independently.
+
+## Step-by-step
+
+The README's setup script runs these in order. Each is a one-liner;
+the comments below say what it does and why.
+
+### Service account
+
+```sh
+gcloud iam service-accounts create stadera-api-deployer --project=$PROJECT
+```
+
+Creates a non-human GCP identity. Same idea as the frontend's
+`stadera-web-deployer` — separate from your user account, separate
+permissions, easy to rotate or revoke.
+
+### Project-level IAM bindings
+
+```sh
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/run.admin
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/artifactregistry.writer
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/iam.serviceAccountUser
+```
+
+The same three roles the frontend deployer needs:
+
+- **`run.admin`** — create / update / delete the Cloud Run service.
+- **`artifactregistry.writer`** — push images.
+- **`iam.serviceAccountUser`** — necessary to deploy a service that
+  runs as a *different* SA (the runtime SA). Without it, deploy fails
+  with "Permission iam.serviceaccounts.actAs denied".
+
+### New WIF provider
+
+```sh
+gcloud iam workload-identity-pools providers create-oidc $PROVIDER \
+    --location=global --workload-identity-pool=$POOL --project=$PROJECT \
+    --display-name="GitHub Actions (stadera backend)" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+    --attribute-condition="assertion.repository=='$GITHUB_REPO'" \
+    --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+Same shape as the frontend's `github-provider`, only:
+
+- `--display-name` distinguishes them in the GCP Console.
+- `--attribute-condition` pins this provider to **the backend repo
+  only**.
+
+The two providers share the pool but are independent objects — you can
+delete `stadera-api-provider` without touching the frontend's auth.
+
+### Bind the repo to the SA
+
+```sh
+POOL_ID=$(gcloud iam workload-identity-pools describe $POOL \
+    --location=global --project=$PROJECT --format='value(name)')
+
+gcloud iam service-accounts add-iam-policy-binding $SA_EMAIL \
+    --project=$PROJECT --role=roles/iam.workloadIdentityUser \
+    --member="principalSet://iam.googleapis.com/$POOL_ID/attribute.repository/$GITHUB_REPO"
+```
+
+The binding lives **on the SA**, not on the pool or provider — because
+*who can impersonate this SA* is a property of the SA itself.
+
+The `principalSet://...attribute.repository/MicheleBellitti/Stadera`
+URI is matched against the OIDC token attributes that pass the
+provider's `attribute-condition`. So the chain is:
+
+1. GitHub OIDC token arrives at GCP STS.
+2. STS routes it to **the provider** that issued the credential
+   configuration (configured via the `WIF_PROVIDER` GitHub secret).
+3. Provider's `attribute-condition` filters out tokens from the wrong
+   repo. Only `MicheleBellitti/Stadera` tokens pass.
+4. STS issues a federated token tagged with the mapped attributes.
+5. The federated token tries to impersonate `stadera-api-deployer`.
+6. The SA's IAM policy is checked: does it have a binding for the
+   principalSet that matches this attribute set? Yes → granted.
+7. Deploy proceeds.
+
+## Cloud Run runtime SA: a thing we're deferring
+
+Right now the deployed Cloud Run service runs as the project's default
+compute SA (`<projectnum>-compute@developer.gserviceaccount.com`).
+That works because:
+
+- The service doesn't need GCP API access at runtime — only DB
+  (Neon, internet) and Withings API (internet).
+- Env vars are set inline by the deploy workflow (no Secret Manager).
+
+When we migrate to Secret Manager (M7-step3 / Terraform), the runtime
+SA needs `secretmanager.secretAccessor` on the specific secrets.
+That's the moment to introduce a dedicated `stadera-api-runtime` SA
+with minimal grants. For step1, default compute SA is fine.
+
+## After the first deploy
+
+The deploy workflow needs `GOOGLE_REDIRECT_URL` as a GitHub variable,
+and that URL doesn't exist until Cloud Run gives you one. Bootstrap
+order:
+
+1. Run the workflow with everything else configured. The
+   redirect-URL-dependent OAuth flow won't work, but `/health` will.
+2. `gcloud run services describe stadera-api --region=$REGION
+    --format='value(status.url)'` → e.g.
+   `https://stadera-api-XXX.europe-west1.run.app`.
+3. Set `GOOGLE_REDIRECT_URL=https://stadera-api-XXX.europe-west1.run.app/auth/google/callback`
+   as a GitHub variable.
+4. Add the same URL to the Google OAuth Console's authorized redirect
+   URIs (under your OAuth client).
+5. Push a trivial commit (or trigger `workflow_dispatch`) to redeploy
+   with the new env var.
+
+You also need to set `FRONTEND_ORIGIN` to the deployed frontend's
+Cloud Run URL. The frontend's `BACKEND_API_URL` becomes this
+backend's URL. The two get coupled at first deploy, then both are
+stable until you delete and recreate.
+
+A custom domain (`api.stadera.app` + `app.stadera.app`) breaks the
+coupling: URLs become stable across infrastructure churn.
+
+## Smoke test
+
+After deploy, hit the health endpoint:
+
+```sh
+URL=$(gcloud run services describe stadera-api --region=$REGION \
+    --format='value(status.url)')
+curl -i $URL/health
+# Expected: HTTP/2 200, body { "status": "ok" }
+```
+
+For the OpenAPI spec:
+
+```sh
+curl $URL/api-docs/openapi.json | jq .info
+# Expected: { "title": "Stadera API", "version": "0.1.0", ... }
+```
+
+If you get a 5xx, check Cloud Logging:
+
+```sh
+gcloud logging read \
+    "resource.type=cloud_run_revision AND resource.labels.service_name=stadera-api" \
+    --limit=50 --format='value(textPayload)' --project=$PROJECT
+```
+
+## References
+
+- [stadera-web walkthrough](https://github.com/MicheleBellitti/stadera-web/blob/main/.claude/docs/deploy-gcp-walkthrough.md) — the long version of WIF
+- [Cloud Run env vars + secrets](https://cloud.google.com/run/docs/configuring/services/environment-variables)
+- [Distroless images](https://github.com/GoogleContainerTools/distroless) — what the runtime stage uses
+- [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) — Rust dep caching for Docker

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Reduce build context size + avoid leaking dev artifacts into the image.
+
+# Build artifacts (re-created in builder stage)
+target
+**/target
+
+# Local env / secrets
+.env
+.env.*
+
+# Git / CI metadata not needed at build time
+.git
+.github
+.gitignore
+.dockerignore
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Tests cache, rustc incremental, etc.
+**/*.rs.bk
+**/.cargo
+
+# rust-toolchain.toml triggers rustup auto-sync on the first cargo
+# call inside the container, which hits static.rust-lang.org and
+# fails behind TLS-MITM proxies. The Docker base image already pins
+# a matching rust version (see Dockerfile ARG), so we use that
+# instead of re-syncing.
+rust-toolchain.toml
+
+# Docs that don't influence the build
+README.md
+CLAUDE.md
+AGENTS.md
+.claude

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,119 @@
+# Build + deploy stadera-api to Cloud Run on every push to main.
+#
+# Same pattern as stadera-web: GitHub OIDC → Workload Identity
+# Federation → GCP service account. No JSON keys.
+#
+# One-time GCP setup (see README "Deploy" section for the full script):
+#   - Artifact Registry repo `stadera` in $GCP_REGION (shared with web)
+#   - Service account `stadera-api-deployer@stadera-prod.iam` with
+#     run.admin, artifactregistry.writer, iam.serviceAccountUser
+#   - Workload Identity Pool provider scoped to this repo
+#     (MicheleBellitti/Stadera) — separate from the web provider
+#
+# GitHub variables (Settings → Secrets and variables → Actions → Variables):
+#   GCP_PROJECT             e.g. stadera-prod
+#   GCP_REGION              e.g. europe-west1
+#   ARTIFACT_REGISTRY_REPO  e.g. stadera
+#   CLOUD_RUN_SERVICE       e.g. stadera-api
+#   FRONTEND_ORIGIN         e.g. https://stadera-web-XXX.europe-west1.run.app
+#   GOOGLE_CLIENT_ID        OAuth client ID (public)
+#   GOOGLE_REDIRECT_URL     ${BACKEND_URL}/auth/google/callback
+#   WITHINGS_CLIENT_ID      Withings client ID (public-ish)
+#
+# GitHub secrets:
+#   WIF_PROVIDER            projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+#   WIF_SERVICE_ACCOUNT     stadera-api-deployer@stadera-prod.iam.gserviceaccount.com
+#   DATABASE_URL            Neon Postgres connection string
+#   GOOGLE_CLIENT_SECRET
+#   WITHINGS_CLIENT_SECRET
+#   WITHINGS_TOKEN_KEY      AES-256 hex key (64 chars)
+#   COOKIE_SECRET           cookie signing key
+#
+# Migration of secrets from GitHub → GCP Secret Manager is M7-step3
+# (Terraform). For step1 we keep them in GitHub for setup simplicity.
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# Cancel a running deploy if a newer commit lands on main.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Cold cargo-chef build is ~5 min, plus push + deploy. 30 min is
+    # generous headroom; warm builds finish in ~2 min total.
+    timeout-minutes: 30
+
+    env:
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/${{ vars.ARTIFACT_REGISTRY_REPO }}/${{ vars.CLOUD_RUN_SERVICE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+
+      # Buildx + GHA cache so the cargo-chef dep layer survives across
+      # workflow runs. Without this, every push pays the full cold-build
+      # cost.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.CLOUD_RUN_SERVICE }}
+          region: ${{ vars.GCP_REGION }}
+          image: ${{ env.IMAGE }}:${{ github.sha }}
+          # Step1 keeps secrets in GitHub Actions and pushes them to
+          # Cloud Run as env vars. Step3 (Terraform) migrates these to
+          # Secret Manager and uses `secrets:` instead of `env_vars:`.
+          env_vars: |
+            FRONTEND_ORIGIN=${{ vars.FRONTEND_ORIGIN }}
+            GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
+            GOOGLE_REDIRECT_URL=${{ vars.GOOGLE_REDIRECT_URL }}
+            WITHINGS_CLIENT_ID=${{ vars.WITHINGS_CLIENT_ID }}
+            COOKIE_SECURE=true
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+            WITHINGS_CLIENT_SECRET=${{ secrets.WITHINGS_CLIENT_SECRET }}
+            WITHINGS_TOKEN_KEY=${{ secrets.WITHINGS_TOKEN_KEY }}
+            COOKIE_SECRET=${{ secrets.COOKIE_SECRET }}
+          flags: >-
+            --port=8080
+            --allow-unauthenticated
+            --min-instances=0
+            --max-instances=2
+            --cpu=1
+            --memory=512Mi
+            --timeout=60

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,16 +18,17 @@
 #   FRONTEND_ORIGIN         e.g. https://stadera-web-XXX.europe-west1.run.app
 #   GOOGLE_CLIENT_ID        OAuth client ID (public)
 #   GOOGLE_REDIRECT_URL     ${BACKEND_URL}/auth/google/callback
-#   WITHINGS_CLIENT_ID      Withings client ID (public-ish)
 #
 # GitHub secrets:
 #   WIF_PROVIDER            projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
 #   WIF_SERVICE_ACCOUNT     stadera-api-deployer@stadera-prod.iam.gserviceaccount.com
 #   DATABASE_URL            Neon Postgres connection string
 #   GOOGLE_CLIENT_SECRET
-#   WITHINGS_CLIENT_SECRET
-#   WITHINGS_TOKEN_KEY      AES-256 hex key (64 chars)
-#   COOKIE_SECRET           cookie signing key
+#
+# `stadera-api` itself only needs the env vars above (see
+# crates/api/src/config.rs). The Withings client_id / client_secret /
+# token_key are read by `stadera-jobs` and the `pair` binary, which
+# deploy separately in M7-step2 (Cloud Run Job + Cloud Scheduler).
 #
 # Migration of secrets from GitHub → GCP Secret Manager is M7-step3
 # (Terraform). For step1 we keep them in GitHub for setup simplicity.
@@ -102,13 +103,9 @@ jobs:
             FRONTEND_ORIGIN=${{ vars.FRONTEND_ORIGIN }}
             GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
             GOOGLE_REDIRECT_URL=${{ vars.GOOGLE_REDIRECT_URL }}
-            WITHINGS_CLIENT_ID=${{ vars.WITHINGS_CLIENT_ID }}
             COOKIE_SECURE=true
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
-            WITHINGS_CLIENT_SECRET=${{ secrets.WITHINGS_CLIENT_SECRET }}
-            WITHINGS_TOKEN_KEY=${{ secrets.WITHINGS_TOKEN_KEY }}
-            COOKIE_SECRET=${{ secrets.COOKIE_SECRET }}
           flags: >-
             --port=8080
             --allow-unauthenticated

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 
 .secrets
+Scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# Multi-stage Rust build for the stadera workspace.
+#
+# Stages:
+#   1. chef    — install cargo-chef so dep compilation can be cached
+#                independently from the rest of the source tree.
+#   2. planner — generate `recipe.json`, the dependency-graph manifest
+#                cargo-chef uses as cache key.
+#   3. builder — build all transitive deps once (`cargo chef cook`),
+#                then build the workspace binaries against the cached
+#                deps. Without cargo-chef, every source change would
+#                invalidate the whole `target/` and re-build axum, sqlx,
+#                reqwest, oauth2, etc. — turning every CI run into a
+#                5-minute build.
+#   4. runtime — distroless cc-debian12: no shell, no apt, ~25 MB base.
+#                Just glibc + libssl + ca-certs, which is exactly what
+#                a Rust binary compiled against bookworm-slim needs.
+#
+# Both binaries (`stadera-api`, `stadera-jobs`) end up in the final image.
+# CMD defaults to `stadera-api`; the Cloud Run Job for sync (M7-step2)
+# overrides CMD to `stadera-jobs sync`.
+
+ARG RUST_VERSION=1.89
+ARG DEBIAN_VERSION=bookworm
+
+# ---- chef -------------------------------------------------------------
+# Pre-built image with cargo-chef already installed — saves ~2 min per
+# cold build vs `cargo install cargo-chef`, and bypasses crates.io TLS
+# during the chef stage. Tag tracks rust-toolchain.toml.
+FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}-slim-${DEBIAN_VERSION} AS chef
+WORKDIR /app
+
+# ---- planner ----------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---- builder ----------------------------------------------------------
+FROM chef AS builder
+
+# Build dependencies first. Cached as a single layer keyed on
+# recipe.json — only invalidated when Cargo.lock or workspace deps
+# change.
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Now bring in the actual source and build only the binaries we ship.
+COPY . .
+RUN cargo build --release --bin stadera-api --bin stadera-jobs
+
+# ---- runtime ----------------------------------------------------------
+# `cc` flavor of distroless: glibc + libgcc + libssl + ca-certs.
+# `nonroot` user (uid 65532) is pre-created. No shell — debugging via
+# Cloud Logging instead of `kubectl exec`.
+FROM gcr.io/distroless/cc-debian12 AS runtime
+
+COPY --from=builder /app/target/release/stadera-api /usr/local/bin/stadera-api
+COPY --from=builder /app/target/release/stadera-jobs /usr/local/bin/stadera-jobs
+# Migrations bundled for future use (Cloud Run Job that applies them).
+COPY --from=builder /app/crates/storage/migrations /app/migrations
+
+USER nonroot
+
+# Cloud Run injects $PORT at runtime; default to 8080 for `docker run`.
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["/usr/local/bin/stadera-api"]

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
-.PHONY: help db-up db-down db-reset db-migrate db-psql check pair sync
+.PHONY: help db-up db-down db-reset db-migrate db-psql check pair sync docker-build docker-run
 
 # Default user-email for pair / sync. Override with: make pair USER_EMAIL=alice@example.com
 USER_EMAIL ?= michelebellitti272@gmail.com
 
+# Image tag for local docker builds. CI uses the GAR path directly.
+IMAGE ?= stadera-api:local
+
 help:
 	@echo "Dev targets:"
-	@echo "  db-up        Start Postgres (Docker Compose)"
-	@echo "  db-down      Stop Postgres"
-	@echo "  db-reset     Destroy volume and recreate + migrate"
-	@echo "  db-migrate   Run sqlx migrations against local DB"
-	@echo "  db-psql      Open psql shell into local DB"
-	@echo "  pair         Run first-time Withings OAuth pairing (USER_EMAIL=...)"
-	@echo "  sync         Run a one-shot Withings sync (USER_EMAIL=...)"
-	@echo "  check        cargo fmt + clippy + test"
+	@echo "  db-up         Start Postgres (Docker Compose)"
+	@echo "  db-down       Stop Postgres"
+	@echo "  db-reset      Destroy volume and recreate + migrate"
+	@echo "  db-migrate    Run sqlx migrations against local DB"
+	@echo "  db-psql       Open psql shell into local DB"
+	@echo "  pair          Run first-time Withings OAuth pairing (USER_EMAIL=...)"
+	@echo "  sync          Run a one-shot Withings sync (USER_EMAIL=...)"
+	@echo "  check         cargo fmt + clippy + test"
+	@echo "  docker-build  Build the Cloud Run image locally (IMAGE=$(IMAGE))"
+	@echo "  docker-run    Run the image locally on :8080 (needs .env)"
 
 db-up:
 	docker compose up -d postgres
@@ -44,3 +49,12 @@ check:
 	cargo fmt --all -- --check
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo test --all
+
+docker-build:
+	docker build -t $(IMAGE) .
+
+# Local smoke test of the production image. Reads env from `.env` so
+# DATABASE_URL points wherever your local backend usually points (e.g.
+# host Postgres via `host.docker.internal`).
+docker-run:
+	docker run --rm -p 8080:8080 --env-file .env $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ In *Settings → Secrets and variables → Actions*:
 - `FRONTEND_ORIGIN` — public URL of the deployed frontend Cloud Run service
 - `GOOGLE_CLIENT_ID` — Google OAuth client ID (public)
 - `GOOGLE_REDIRECT_URL` — `${BACKEND_URL}/auth/google/callback`
-- `WITHINGS_CLIENT_ID` — Withings client ID
 
 **Secrets** (real credentials):
 
@@ -148,9 +147,13 @@ In *Settings → Secrets and variables → Actions*:
 - `WIF_SERVICE_ACCOUNT` — `stadera-api-deployer@<project>.iam.gserviceaccount.com`
 - `DATABASE_URL` — Neon Postgres connection string
 - `GOOGLE_CLIENT_SECRET`
-- `WITHINGS_CLIENT_SECRET`
-- `WITHINGS_TOKEN_KEY` — 64-hex-char AES-256 key for token encryption
-- `COOKIE_SECRET` — cookie signing key
+
+`stadera-api` reads only the variables above (see
+`crates/api/src/config.rs`). Sessions are server-side opaque IDs in
+the `sessions` table — no cookie-signing key needed. The Withings
+`client_id` / `client_secret` / `token_key` are read only by
+`stadera-jobs` and the `pair` binary, deployed separately in
+M7-step2.
 
 ### Bootstrap order
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,177 @@
 # Stadera
 
-Personal weight tracking & nutrition coaching API, powered by Withings smart scales.
+Personal weight tracking & nutrition coaching API, powered by Withings
+smart scales.
 
 Named after the *stadera romana*, the ancient steelyard balance.
 
 ## Status
 
-Early development.
+M5 complete (API + frontend). M7-step1 (backend Cloud Run deploy) in
+progress. M6 (notifications), M7-step2/3 (sync job + Terraform IaC) and
+optional backlog issues are next.
 
 ## Architecture
 
-- Rust backend (axum + sqlx + Tokio)
-- PostgreSQL (Neon)
-- Google Cloud Run deployment
-- Next.js frontend (separate repo: stadera-web)
+- Rust backend (axum + sqlx + Tokio), workspace under `crates/`
+  - `domain` — pure business logic, no I/O
+  - `storage` — Postgres repository pattern, sqlx migrations
+  - `withings` — Withings OAuth2 + Health Mate API client
+  - `api` — axum HTTP server (binary)
+  - `jobs` — cron binary for daily sync
+- Postgres (Neon, serverless)
+- Google Cloud Run for both `api` (service) and `jobs` (job, M7-step2)
+- Next.js frontend in [stadera-web](https://github.com/MicheleBellitti/stadera-web)
 
-## Development
+## Local development
 
-TBD — see M1.
+Requires:
+
+- Rust (toolchain pinned in `rust-toolchain.toml`)
+- Docker for Postgres
+- `sqlx-cli` for migrations: `cargo install sqlx-cli --no-default-features -F postgres,rustls`
+
+Common targets (see `make help`):
+
+```sh
+make db-up         # start local Postgres on :5432
+make db-migrate    # apply migrations
+make pair USER_EMAIL=...   # one-shot Withings OAuth pairing
+make sync USER_EMAIL=...   # one-shot Withings sync
+make check         # fmt + clippy + test (CI gate)
+```
+
+Env vars are read from `.env` (auto-loaded via `dotenvy`). No
+`.env.example` — required vars listed in `crates/api/src/config.rs`.
+
+## Deploy
+
+Cloud Run, scale-to-zero, deployed on every push to `main` via
+`.github/workflows/deploy.yml`. Auth is via Workload Identity Federation
+— no JSON service-account keys.
+
+### Container layout
+
+`Dockerfile` is a 4-stage build using `cargo-chef` so dependency
+compilation is cached as a separate Docker layer. Without this, every
+source change re-builds axum/sqlx/reqwest/oauth2 from scratch (~5 min).
+With it, source-only changes finish in ~30 s.
+
+```
+chef    → install cargo-chef
+planner → cargo chef prepare → recipe.json (dependency manifest)
+builder → cargo chef cook (builds all deps), then cargo build (binaries)
+runtime → distroless cc-debian12, ~25 MB base, both binaries copied in
+```
+
+Final image is ~120 MB. CMD defaults to `stadera-api`; the Cloud Run
+Job for the daily sync (M7-step2) overrides CMD to `stadera-jobs sync`.
+
+```sh
+# Local smoke test
+make docker-build
+make docker-run        # binds :8080, reads .env
+```
+
+### One-time GCP setup
+
+These run once per project. The frontend setup
+([stadera-web README](https://github.com/MicheleBellitti/stadera-web#deploy))
+already creates the Artifact Registry repo and the Workload Identity
+Pool — we reuse them here, only the service account and the
+provider-per-repo are new.
+
+For a step-by-step explanation of each `gcloud` command, see
+[`.claude/docs/deploy-gcp-walkthrough.md`](.claude/docs/deploy-gcp-walkthrough.md).
+
+```sh
+PROJECT=...                      # GCP project ID
+REGION=europe-west1
+REPO=stadera                     # Artifact Registry repo (shared with web)
+SERVICE=stadera-api
+SA=stadera-api-deployer
+SA_EMAIL=$SA@$PROJECT.iam.gserviceaccount.com
+
+POOL=github-pool                 # reuse from web setup
+PROVIDER=stadera-api-provider    # new: scoped to this repo
+GITHUB_REPO=MicheleBellitti/Stadera
+
+# 1. Service account for deploys
+gcloud iam service-accounts create $SA --project=$PROJECT
+
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/run.admin
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/artifactregistry.writer
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:$SA_EMAIL" --role=roles/iam.serviceAccountUser
+
+# 2. New OIDC provider in the existing pool, scoped to THIS repo
+gcloud iam workload-identity-pools providers create-oidc $PROVIDER \
+    --location=global --workload-identity-pool=$POOL --project=$PROJECT \
+    --display-name="GitHub Actions (stadera backend)" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+    --attribute-condition="assertion.repository=='$GITHUB_REPO'" \
+    --issuer-uri="https://token.actions.githubusercontent.com"
+
+# 3. Bind GitHub repo identity → service account
+POOL_ID=$(gcloud iam workload-identity-pools describe $POOL \
+    --location=global --project=$PROJECT --format='value(name)')
+
+gcloud iam service-accounts add-iam-policy-binding $SA_EMAIL \
+    --project=$PROJECT --role=roles/iam.workloadIdentityUser \
+    --member="principalSet://iam.googleapis.com/$POOL_ID/attribute.repository/$GITHUB_REPO"
+
+# 4. Print the values to paste into GitHub secrets
+echo "WIF_PROVIDER       = $POOL_ID/providers/$PROVIDER"
+echo "WIF_SERVICE_ACCOUNT = $SA_EMAIL"
+```
+
+### GitHub configuration
+
+In *Settings → Secrets and variables → Actions*:
+
+**Variables** (non-secret operational config):
+
+- `GCP_PROJECT` — GCP project ID
+- `GCP_REGION` — e.g. `europe-west1`
+- `ARTIFACT_REGISTRY_REPO` — `stadera`
+- `CLOUD_RUN_SERVICE` — `stadera-api`
+- `FRONTEND_ORIGIN` — public URL of the deployed frontend Cloud Run service
+- `GOOGLE_CLIENT_ID` — Google OAuth client ID (public)
+- `GOOGLE_REDIRECT_URL` — `${BACKEND_URL}/auth/google/callback`
+- `WITHINGS_CLIENT_ID` — Withings client ID
+
+**Secrets** (real credentials):
+
+- `WIF_PROVIDER` — full resource path printed by step 4 above
+- `WIF_SERVICE_ACCOUNT` — `stadera-api-deployer@<project>.iam.gserviceaccount.com`
+- `DATABASE_URL` — Neon Postgres connection string
+- `GOOGLE_CLIENT_SECRET`
+- `WITHINGS_CLIENT_SECRET`
+- `WITHINGS_TOKEN_KEY` — 64-hex-char AES-256 key for token encryption
+- `COOKIE_SECRET` — cookie signing key
+
+### Bootstrap order
+
+The first deploy is chicken-and-egg: `GOOGLE_REDIRECT_URL` depends on
+the Cloud Run service URL, which only exists after the first deploy.
+
+1. Set everything except `GOOGLE_REDIRECT_URL` (or set a placeholder).
+2. Trigger the workflow (push to `main` or manual `workflow_dispatch`).
+3. Once deployed, copy the service URL:
+   ```sh
+   gcloud run services describe stadera-api --region=europe-west1 \
+       --format='value(status.url)'
+   ```
+4. Set `GOOGLE_REDIRECT_URL=<URL>/auth/google/callback` as a GitHub
+   variable, AND add it to the Google OAuth Console authorized
+   redirect URIs.
+5. Re-trigger the workflow so the new env var is picked up.
+
+When you eventually move to a custom domain (`api.stadera.app`), the
+URL becomes stable and step 5 isn't needed on subsequent infrastructure
+churns.
 
 ## License
 


### PR DESCRIPTION
M7-step1: backend Cloud Run deploy infrastructure.

- Dockerfile: 4-stage Rust build using cargo-chef so deps compile in a separate, cacheable Docker layer. Cold build ~5 min; source-only changes ~30 s.
  - chef stage uses lukemathwalker/cargo-chef:rust-1.89-slim-bookworm (skips installing cargo-chef on every cold build).
  - Both binaries (stadera-api, stadera-jobs) end up in the runtime image. CMD defaults to stadera-api; the future Cloud Run Job for sync (M7-step2) overrides CMD to stadera-jobs sync.
  - Runtime stage is gcr.io/distroless/cc-debian12 (~25 MB base): glibc + libssl + ca-certs, no shell, runs as nonroot.
  - Final image ~120 MB.
- .dockerignore: trims context (target/, .git, etc.) and excludes rust-toolchain.toml because rustup auto-syncs the channel on the first cargo invocation, which fails behind TLS-MITM proxies. The base image already pins matching Rust, so the toolchain file would just trigger a redundant network call.
- .github/workflows/deploy.yml: build → push to Artifact Registry → deploy to Cloud Run on push to main, auth via Workload Identity Federation (no JSON keys). Uses docker buildx with GHA cache so the cargo-chef dep layer survives across runs.
- Makefile: docker-build / docker-run targets for local smoke testing (works on networks without TLS-MITM; otherwise CI is the validation path).
- README "Deploy" section: full GCP setup script, GitHub Variables/Secrets list, and the bootstrap-order notes (first deploy has chicken-and-egg with GOOGLE_REDIRECT_URL).
- .claude/docs/deploy-gcp-walkthrough.md: companion doc that points to the frontend's WIF walkthrough and only explains what's different for the backend (separate provider per repo, runtime SA deferred to step3, smoke test commands).

NOT YET in this PR (later iterations):
- M7-step2: Cloud Run Job + Cloud Scheduler for daily sync
- M7-step3: Terraform IaC + migration to Secret Manager for runtime secrets

