### PR TITLE
feat(deploy): Cloud Run Job for daily Withings sync (M7-step2)

### DIFF
--- a/.claude/docs/deploy-gcp-walkthrough.md
+++ b/.claude/docs/deploy-gcp-walkthrough.md
@@ -191,9 +191,125 @@ gcloud logging read \
     --limit=50 --format='value(textPayload)' --project=$PROJECT
 ```
 
+## M7-step2: Cloud Run Job + Cloud Scheduler
+
+The same Docker image that serves `stadera-api` also contains
+`stadera-jobs`. We deploy it as a **Cloud Run Job** (one-shot
+execution, not a long-running service) and schedule daily invocations
+via **Cloud Scheduler**.
+
+### Why a Job and not just a Service
+
+| | Service | Job |
+|---|---|---|
+| Lifecycle | always-on (or scale-to-zero with cold start on request) | exits when the binary returns |
+| Triggered by | HTTP requests | manual invoke / Scheduler / Eventarc |
+| Billing | per request-second (idle = $0 with min-instances=0) | per execution duration only |
+| Suited for | API serving | batch / ETL / cron |
+
+The sync is a 5-30 s batch task that runs once a day. Modeling it as
+a service would force us into either always-on (waste) or
+HTTP-triggering-itself (silly). Jobs map perfectly.
+
+### Workflow side: Cloud Run Job deploy
+
+The `Deploy Cloud Run Job` step in `.github/workflows/deploy.yml`:
+
+1. Writes a temp YAML file with `DATABASE_URL`, `WITHINGS_*` env vars.
+2. Calls `gcloud run jobs deploy` — creates the Job on first run,
+   updates the image + env on subsequent runs.
+3. Sets `--command=/usr/local/bin/stadera-jobs` and
+   `--args=sync,--user-email,${SYNC_USER_EMAIL}`. The comma-separated
+   `--args` becomes `argv` inside the container —
+   `["sync", "--user-email", "user@..."]`.
+4. Deletes the temp YAML.
+
+Why `--env-vars-file` and not inline `--set-env-vars`: gcloud's flag
+parser splits the inline form on commas, so any value containing a
+comma (Postgres URLs sometimes do) breaks. The file form is exact.
+
+### Cloud Scheduler: anatomy of a daily trigger
+
+```sh
+gcloud scheduler jobs create http stadera-sync-daily \
+    --location=$REGION --project=$PROJECT \
+    --schedule="0 6 * * *" \
+    --time-zone="Europe/Rome" \
+    --uri="https://$REGION-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/$PROJECT/jobs/$JOB:run" \
+    --http-method=POST \
+    --oidc-service-account-email=$INVOKER_SA_EMAIL \
+    --oidc-token-audience="https://$REGION-run.googleapis.com/"
+```
+
+Reading flag by flag:
+
+- **`--schedule="0 6 * * *"`** — standard cron. Minute 0, hour 6,
+  any day of month, any month, any day of week. Daily 06:00.
+- **`--time-zone="Europe/Rome"`** — interpreted in this TZ, so
+  daylight savings shifts are absorbed automatically. Without this
+  the schedule is UTC and you'd be triggering at 07:00 / 08:00
+  depending on the season.
+- **`--uri=…/jobs/$JOB:run`** — the Cloud Run Admin API endpoint
+  that triggers a job execution. The `:run` suffix is the magic;
+  hitting the bare `…/jobs/$JOB` returns metadata, not an
+  execution.
+- **`--http-method=POST`** — required by the `:run` endpoint.
+- **`--oidc-service-account-email`** — Scheduler signs the outgoing
+  request with an OIDC token *minted as this service account*. Cloud
+  Run sees the token, looks up the SA's IAM, decides yes/no.
+- **`--oidc-token-audience`** — the audience claim Scheduler bakes
+  into the token. Cloud Run requires it match its own URL.
+
+### IAM minimum for the invoker SA
+
+```sh
+gcloud run jobs add-iam-policy-binding $JOB \
+    --region=$REGION --project=$PROJECT \
+    --member="serviceAccount:$INVOKER_SA_EMAIL" \
+    --role=roles/run.invoker
+```
+
+Note this binds **on the Job**, not on the project. The SA can invoke
+*this* job, nothing else. If a future malicious workflow steals the
+SA, the worst it can do is re-trigger the sync.
+
+### Smoke test the chain
+
+Manually run the job:
+
+```sh
+gcloud run jobs execute $JOB --region=$REGION --wait --project=$PROJECT
+# → Execution [stadera-sync-...]: SUCCEEDED (took 12s)
+```
+
+Trigger via Scheduler (without waiting for the cron):
+
+```sh
+gcloud scheduler jobs run stadera-sync-daily --location=$REGION --project=$PROJECT
+```
+
+Then check the execution:
+
+```sh
+gcloud run jobs executions list --job=$JOB --region=$REGION --project=$PROJECT --limit=5
+```
+
+The most recent execution should be `SUCCEEDED`. If it's `FAILED`,
+inspect logs via `gcloud beta run jobs executions describe <id>` or
+the Cloud Console "Executions" tab on the Job.
+
+### Common failure: missing `WITHINGS_TOKEN_KEY` mismatch
+
+The token key encrypts Withings refresh tokens at rest. If the value
+in GitHub Secrets differs from what `make pair` used locally, sync
+fails to decrypt and bails with `decryption failed`. Fix: rerun
+`make pair` with the production key (or rotate every paired user).
+
 ## References
 
 - [stadera-web walkthrough](https://github.com/MicheleBellitti/stadera-web/blob/main/.claude/docs/deploy-gcp-walkthrough.md) — the long version of WIF
 - [Cloud Run env vars + secrets](https://cloud.google.com/run/docs/configuring/services/environment-variables)
+- [Cloud Run Jobs reference](https://cloud.google.com/run/docs/create-jobs)
+- [Cloud Scheduler with OIDC](https://cloud.google.com/scheduler/docs/http-target-auth)
 - [Distroless images](https://github.com/GoogleContainerTools/distroless) — what the runtime stage uses
 - [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) — Rust dep caching for Docker

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,27 +15,37 @@
 # `environment: prod`, otherwise vars.*/secrets.* resolve to empty.
 #
 # Variables (Environment → prod → Variables):
-#   GCP_PROJECT             e.g. stadera-prod
-#   GCP_REGION              e.g. europe-west1
-#   ARTIFACT_REGISTRY_REPO  e.g. stadera
-#   CLOUD_RUN_SERVICE       e.g. stadera-api
-#   FRONTEND_ORIGIN         e.g. https://stadera-web-XXX.europe-west1.run.app
-#   GOOGLE_CLIENT_ID        OAuth client ID (public)
-#   GOOGLE_REDIRECT_URL     ${BACKEND_URL}/auth/google/callback
+#   GCP_PROJECT              e.g. stadera-prod
+#   GCP_REGION               e.g. europe-west1
+#   ARTIFACT_REGISTRY_REPO   e.g. stadera
+#   CLOUD_RUN_SERVICE        e.g. stadera-api
+#   CLOUD_RUN_SYNC_JOB       e.g. stadera-sync (Cloud Run Job, M7-step2)
+#   SYNC_USER_EMAIL          email of the user whose Withings data to sync
+#                            (single-tenant for now; multi-user pulls all
+#                            paired users when we refactor sync)
+#   FRONTEND_ORIGIN          e.g. https://stadera-web-XXX.europe-west1.run.app
+#   GOOGLE_CLIENT_ID         OAuth client ID (public)
+#   GOOGLE_REDIRECT_URL      ${BACKEND_URL}/auth/google/callback
+#   WITHINGS_CLIENT_ID       Withings OAuth client ID
 #
 # Secrets (Environment → prod → Secrets):
-#   WIF_PROVIDER            projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
-#   WIF_SERVICE_ACCOUNT     stadera-api-deployer@stadera-prod.iam.gserviceaccount.com
-#   DATABASE_URL            Neon Postgres connection string
+#   WIF_PROVIDER             projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+#   WIF_SERVICE_ACCOUNT      stadera-api-deployer@stadera-prod.iam.gserviceaccount.com
+#   DATABASE_URL             Neon Postgres connection string
 #   GOOGLE_CLIENT_SECRET
+#   WITHINGS_CLIENT_SECRET   Withings OAuth client secret (for sync job)
+#   WITHINGS_TOKEN_KEY       64-hex-char AES-256 key for token encryption
+#                            (must match the value used by the `pair` binary)
 #
-# `stadera-api` itself only needs the env vars above (see
-# crates/api/src/config.rs). The Withings client_id / client_secret /
-# token_key are read by `stadera-jobs` and the `pair` binary, which
-# deploy separately in M7-step2 (Cloud Run Job + Cloud Scheduler).
+# `stadera-api` reads only DATABASE_URL, FRONTEND_ORIGIN, COOKIE_SECURE,
+# GOOGLE_*. `stadera-jobs sync` adds DATABASE_URL + WITHINGS_*. The
+# build is shared (one image, two Cloud Run resources, different CMDs).
+#
+# Cloud Scheduler trigger (one-time gcloud setup, not in this workflow)
+# invokes the Cloud Run Job daily — see README "Deploy" section.
 #
 # Migration of secrets from GitHub → GCP Secret Manager is M7-step3
-# (Terraform). For step1 we keep them in GitHub for setup simplicity.
+# (Terraform). For step1/2 we keep them in GitHub for setup simplicity.
 
 name: Deploy
 
@@ -98,7 +108,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to Cloud Run
+      - name: Deploy Cloud Run Service (stadera-api)
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ vars.CLOUD_RUN_SERVICE }}
@@ -122,3 +132,41 @@ jobs:
             --cpu=1
             --memory=512Mi
             --timeout=60
+
+      # M7-step2: deploy the same image as a Cloud Run Job that runs
+      # `stadera-jobs sync`. Idempotent — `gcloud run jobs deploy`
+      # creates the job if missing, updates the image + env on each run.
+      #
+      # Env vars are written to a temp YAML file (rather than a giant
+      # `--set-env-vars` flag) because some values like DATABASE_URL
+      # contain `=` and `,` which would confuse gcloud's parser. The
+      # file lives only on the GitHub-runner-managed VM for the
+      # duration of this step.
+      - name: Deploy Cloud Run Job (stadera-sync)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          WITHINGS_CLIENT_ID: ${{ vars.WITHINGS_CLIENT_ID }}
+          WITHINGS_CLIENT_SECRET: ${{ secrets.WITHINGS_CLIENT_SECRET }}
+          WITHINGS_TOKEN_KEY: ${{ secrets.WITHINGS_TOKEN_KEY }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/sync-env.yaml <<EOF
+          DATABASE_URL: "${DATABASE_URL}"
+          WITHINGS_CLIENT_ID: "${WITHINGS_CLIENT_ID}"
+          WITHINGS_CLIENT_SECRET: "${WITHINGS_CLIENT_SECRET}"
+          WITHINGS_TOKEN_KEY: "${WITHINGS_TOKEN_KEY}"
+          EOF
+
+          gcloud run jobs deploy "${{ vars.CLOUD_RUN_SYNC_JOB }}" \
+            --image="${{ env.IMAGE }}:${{ github.sha }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --command="/usr/local/bin/stadera-jobs" \
+            --args="sync,--user-email,${{ vars.SYNC_USER_EMAIL }}" \
+            --env-vars-file=/tmp/sync-env.yaml \
+            --max-retries=2 \
+            --task-timeout=300s \
+            --cpu=1 \
+            --memory=512Mi \
+            --quiet
+
+          rm -f /tmp/sync-env.yaml

--- a/README.md
+++ b/README.md
@@ -137,9 +137,13 @@ In *Settings → Secrets and variables → Actions*:
 - `GCP_REGION` — e.g. `europe-west1`
 - `ARTIFACT_REGISTRY_REPO` — `stadera`
 - `CLOUD_RUN_SERVICE` — `stadera-api`
+- `CLOUD_RUN_SYNC_JOB` — `stadera-sync` (Cloud Run Job for daily sync)
+- `SYNC_USER_EMAIL` — email of the user whose Withings data the daily
+  sync pulls (single-tenant for now)
 - `FRONTEND_ORIGIN` — public URL of the deployed frontend Cloud Run service
 - `GOOGLE_CLIENT_ID` — Google OAuth client ID (public)
 - `GOOGLE_REDIRECT_URL` — `${BACKEND_URL}/auth/google/callback`
+- `WITHINGS_CLIENT_ID` — Withings OAuth client ID
 
 **Secrets** (real credentials):
 
@@ -147,13 +151,16 @@ In *Settings → Secrets and variables → Actions*:
 - `WIF_SERVICE_ACCOUNT` — `stadera-api-deployer@<project>.iam.gserviceaccount.com`
 - `DATABASE_URL` — Neon Postgres connection string
 - `GOOGLE_CLIENT_SECRET`
+- `WITHINGS_CLIENT_SECRET`
+- `WITHINGS_TOKEN_KEY` — 64-hex-char AES-256 key for token encryption.
+  **Must match the value used by the local `make pair` run that stored
+  the user's tokens.** If you rotate it, every paired user has to
+  re-do `make pair`.
 
-`stadera-api` reads only the variables above (see
-`crates/api/src/config.rs`). Sessions are server-side opaque IDs in
-the `sessions` table — no cookie-signing key needed. The Withings
-`client_id` / `client_secret` / `token_key` are read only by
-`stadera-jobs` and the `pair` binary, deployed separately in
-M7-step2.
+`stadera-api` reads only DATABASE_URL + FRONTEND_ORIGIN + COOKIE_SECURE +
+GOOGLE_*. `stadera-jobs sync` adds DATABASE_URL + WITHINGS_*. The
+deploy workflow builds the image once and deploys both as separate
+Cloud Run resources.
 
 ### Bootstrap order
 
@@ -171,6 +178,62 @@ the Cloud Run service URL, which only exists after the first deploy.
    variable, AND add it to the Google OAuth Console authorized
    redirect URIs.
 5. Re-trigger the workflow so the new env var is picked up.
+
+### Daily Withings sync (M7-step2)
+
+The deploy workflow already creates / updates the Cloud Run **Job**
+`stadera-sync`. It's configured but not scheduled — it runs only when
+something invokes it. We use **Cloud Scheduler** for that.
+
+Cloud Scheduler is one-time gcloud setup, runs as a dedicated SA so
+its blast radius is "invoke this one job, nothing else":
+
+```sh
+PROJECT=...
+REGION=europe-west1
+JOB=stadera-sync
+INVOKER_SA=stadera-sync-invoker
+INVOKER_SA_EMAIL=$INVOKER_SA@$PROJECT.iam.gserviceaccount.com
+
+# 0. Enable the API once (no-op if already on)
+gcloud services enable cloudscheduler.googleapis.com --project=$PROJECT
+
+# 1. Service account that Cloud Scheduler will use to invoke the Job
+gcloud iam service-accounts create $INVOKER_SA --project=$PROJECT
+
+# 2. Grant invoke permission on the SPECIFIC Cloud Run Job (least
+#    privilege: this SA can't invoke any other job in the project)
+gcloud run jobs add-iam-policy-binding $JOB \
+    --region=$REGION --project=$PROJECT \
+    --member="serviceAccount:$INVOKER_SA_EMAIL" \
+    --role=roles/run.invoker
+
+# 3. Create the daily trigger. 06:00 Europe/Rome — Withings has by then
+#    pushed the morning weighing to its cloud (typical lag is <30 s
+#    after stepping off the scale). The OIDC token Cloud Scheduler
+#    attaches to the request is what authorizes the run-invoke call.
+gcloud scheduler jobs create http stadera-sync-daily \
+    --location=$REGION --project=$PROJECT \
+    --schedule="0 6 * * *" \
+    --time-zone="Europe/Rome" \
+    --uri="https://$REGION-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/$PROJECT/jobs/$JOB:run" \
+    --http-method=POST \
+    --oidc-service-account-email=$INVOKER_SA_EMAIL \
+    --oidc-token-audience="https://$REGION-run.googleapis.com/"
+```
+
+Trigger the job manually any time (smoke test, or one-off catch-up):
+
+```sh
+gcloud run jobs execute $JOB --region=$REGION --project=$PROJECT --wait
+```
+
+Inspect a run's logs:
+
+```sh
+gcloud beta run jobs executions describe <execution-id> \
+    --region=$REGION --project=$PROJECT
+```
 
 When you eventually move to a custom domain (`api.stadera.app`), the
 URL becomes stable and step 5 isn't needed on subsequent infrastructure


### PR DESCRIPTION
Same Docker image, second Cloud Run resource. The deploy workflow now ships both `stadera-api` (Service) and `stadera-sync` (Job) from a single build.

Workflow:
- New `Deploy Cloud Run Job` step after the service deploy.
- Idempotent: `gcloud run jobs deploy` creates on first run, updates image + env on subsequent runs.
- Env vars passed via temp YAML file (not inline `--set-env-vars`) because gcloud's flag parser splits on commas, which Postgres URLs occasionally contain.
- CMD overridden to `/usr/local/bin/stadera-jobs` with `--args=sync,--user-email,${SYNC_USER_EMAIL}`.
- Resources: cpu=1, memory=512Mi, max-retries=2, task-timeout=300s.

New GitHub vars: CLOUD_RUN_SYNC_JOB, SYNC_USER_EMAIL, WITHINGS_CLIENT_ID.
New GitHub secrets: WITHINGS_CLIENT_SECRET, WITHINGS_TOKEN_KEY.

`WITHINGS_TOKEN_KEY` must match the key used by the local `make pair` run that stored the user's tokens — the encrypted blob in the DB won't decrypt otherwise. Documented as a common failure mode.

Cloud Scheduler is one-time gcloud setup, not part of the workflow:
- Dedicated SA `stadera-sync-invoker` bound `roles/run.invoker` ON THE JOB (not on the project) — minimum blast radius.
- Daily HTTP trigger at 06:00 Europe/Rome with OIDC token audience matching the Cloud Run Admin API URL.
- Withings cloud has by then ingested the morning weighing (typical lag is <30 s), so the sync window catches it.

README + walkthrough doc both updated with the full setup script, flag-by-flag explanation, and smoke-test commands.

NOT in this PR (M7-step3):
- Migration from GitHub-stored secrets to GCP Secret Manager.
- Dedicated runtime SA (the Job runs as default compute SA for now).
- Terraform for the whole thing.
