### PR TITLE
feat(api): COOKIE_DOMAIN config for cross-subdomain cookies

### DIFF
--- a/.claude/docs/deploy-gcp-walkthrough.md
+++ b/.claude/docs/deploy-gcp-walkthrough.md
@@ -305,6 +305,58 @@ in GitHub Secrets differs from what `make pair` used locally, sync
 fails to decrypt and bails with `decryption failed`. Fix: rerun
 `make pair` with the production key (or rotate every paired user).
 
+## Custom domain mapping (cookie cross-subdomain)
+
+The auto-generated `*.run.app` URLs work, but session cookies don't
+cross between two `*.run.app` subdomains (browsers won't share cookies
+across hosts that aren't a parent/child relationship through the
+public-suffix list — and `run.app` is a public suffix). With FE on
+`stadera-web-X.run.app` and BE on `stadera-api-Y.run.app`, the BE-set
+cookie is invisible to the FE host → /me from FE always sees 401.
+
+A custom domain solves it:
+
+```sh
+DOMAIN=stadera.org   # owned by you, DNS managed by Cloudflare or similar
+
+gcloud beta run domain-mappings create \
+    --service=stadera-api --domain="api.$DOMAIN" \
+    --region=$REGION --project=$PROJECT
+
+gcloud beta run domain-mappings create \
+    --service=stadera-web --domain="app.$DOMAIN" \
+    --region=$REGION --project=$PROJECT
+```
+
+`gcloud` prints CNAME records to add to your DNS provider:
+
+```
+api.stadera.org   CNAME   ghs.googlehosted.com
+app.stadera.org   CNAME   ghs.googlehosted.com
+```
+
+DNS propagation: ~5-30 min. Cloud Run auto-provisions Let's Encrypt
+TLS certs once the CNAMEs resolve correctly (~5 min more).
+
+After DNS + TLS:
+
+1. Set GitHub Variable `COOKIE_DOMAIN=.stadera.org`. The leading dot
+   isn't strictly required by RFC 6265bis but many HTTP clients still
+   prefer it for "shared across all subdomains" semantics.
+2. Set `FRONTEND_ORIGIN=https://app.stadera.org` and
+   `GOOGLE_REDIRECT_URL=https://api.stadera.org/auth/google/callback`.
+3. Add `https://api.stadera.org/auth/google/callback` to the Google
+   OAuth Console authorized redirect URIs.
+4. Update the frontend's `BACKEND_API_URL` GitHub Variable to
+   `https://api.stadera.org`.
+5. Re-trigger both repos' deploy workflows so the new env values are
+   picked up.
+
+After that, sign-in on `https://app.stadera.org` sets a cookie with
+`Domain=.stadera.org` → browser sends it to both `app.*` and `api.*`
+→ the FE's server-side `/me` gate works and the user lands on
+`/dashboard`.
+
 ## References
 
 - [stadera-web walkthrough](https://github.com/MicheleBellitti/stadera-web/blob/main/.claude/docs/deploy-gcp-walkthrough.md) — the long version of WIF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,12 @@
 #   SYNC_USER_EMAIL          email of the user whose Withings data to sync
 #                            (single-tenant for now; multi-user pulls all
 #                            paired users when we refactor sync)
-#   FRONTEND_ORIGIN          e.g. https://stadera-web-XXX.europe-west1.run.app
+#   FRONTEND_ORIGIN          e.g. https://app.stadera.org
+#   COOKIE_DOMAIN            e.g. .stadera.org — required when FE and BE
+#                            are on different subdomains of a common
+#                            parent. Leave unset / empty for single-host
+#                            deployments. Must be a parent of the
+#                            backend's actual hostname.
 #   GOOGLE_CLIENT_ID         OAuth client ID (public)
 #   GOOGLE_REDIRECT_URL      ${BACKEND_URL}/auth/google/callback
 #   WITHINGS_CLIENT_ID       Withings OAuth client ID
@@ -119,6 +124,7 @@ jobs:
           # Secret Manager and uses `secrets:` instead of `env_vars:`.
           env_vars: |
             FRONTEND_ORIGIN=${{ vars.FRONTEND_ORIGIN }}
+            COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
             GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
             GOOGLE_REDIRECT_URL=${{ vars.GOOGLE_REDIRECT_URL }}
             COOKIE_SECURE=true

--- a/README.md
+++ b/README.md
@@ -140,9 +140,15 @@ In *Settings → Secrets and variables → Actions*:
 - `CLOUD_RUN_SYNC_JOB` — `stadera-sync` (Cloud Run Job for daily sync)
 - `SYNC_USER_EMAIL` — email of the user whose Withings data the daily
   sync pulls (single-tenant for now)
-- `FRONTEND_ORIGIN` — public URL of the deployed frontend Cloud Run service
+- `FRONTEND_ORIGIN` — public URL of the deployed frontend
+  (e.g. `https://app.stadera.org`)
+- `COOKIE_DOMAIN` — `.stadera.org` once you map FE + BE under the same
+  custom domain. Leave unset for single-host (auto-generated
+  `*.run.app`) deployments. Required when FE and BE are on different
+  subdomains so the session cookie is shared.
 - `GOOGLE_CLIENT_ID` — Google OAuth client ID (public)
 - `GOOGLE_REDIRECT_URL` — `${BACKEND_URL}/auth/google/callback`
+  (e.g. `https://api.stadera.org/auth/google/callback`)
 - `WITHINGS_CLIENT_ID` — Withings OAuth client ID
 
 **Secrets** (real credentials):

--- a/crates/api/src/auth/cookies.rs
+++ b/crates/api/src/auth/cookies.rs
@@ -1,7 +1,17 @@
 //! Cookie name constants and helper builders.
 //!
-//! All cookies are `HttpOnly` and `SameSite=Lax`. The `Secure` flag is set
-//! in production (HTTPS) via the `cookie_secure` config flag.
+//! All cookies are `HttpOnly` and `SameSite=Lax`. The `Secure` flag is
+//! set in production (HTTPS) via the `cookie_secure` config flag.
+//!
+//! `domain` is optional. When `None` (default) the browser scopes the
+//! cookie to the exact host that set it — fine for dev (`localhost`)
+//! and single-host prod. When `Some(".stadera.org")` the cookie is
+//! shared across all subdomains, required when FE and BE are on
+//! different subdomains of a common parent.
+//!
+//! Cleared cookies must use the **same domain** attribute as the
+//! original — otherwise the browser sees the clear as a distinct
+//! cookie and won't actually expire the live one.
 
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use time::Duration;
@@ -19,42 +29,62 @@ const SESSION_TTL: Duration = Duration::days(30);
 /// OAuth state cookie max age (10 minutes) — covers a normal consent flow.
 const OAUTH_STATE_TTL: Duration = Duration::minutes(10);
 
-pub fn build_session_cookie(value: String, secure: bool) -> Cookie<'static> {
-    Cookie::build((SESSION_COOKIE, value))
+pub fn build_session_cookie(value: String, secure: bool, domain: Option<&str>) -> Cookie<'static> {
+    let mut c = Cookie::build((SESSION_COOKIE, value))
         .http_only(true)
         .secure(secure)
         .same_site(SameSite::Lax)
         .path("/")
         .max_age(SESSION_TTL)
-        .build()
+        .build();
+    if let Some(d) = domain {
+        c.set_domain(d.to_string());
+    }
+    c
 }
 
-pub fn clear_session_cookie(secure: bool) -> Cookie<'static> {
-    Cookie::build((SESSION_COOKIE, ""))
+pub fn clear_session_cookie(secure: bool, domain: Option<&str>) -> Cookie<'static> {
+    let mut c = Cookie::build((SESSION_COOKIE, ""))
         .http_only(true)
         .secure(secure)
         .same_site(SameSite::Lax)
         .path("/")
         .max_age(Duration::ZERO)
-        .build()
+        .build();
+    if let Some(d) = domain {
+        c.set_domain(d.to_string());
+    }
+    c
 }
 
-pub fn build_oauth_state_cookie(value: String, secure: bool) -> Cookie<'static> {
-    Cookie::build((OAUTH_STATE_COOKIE, value))
+pub fn build_oauth_state_cookie(
+    value: String,
+    secure: bool,
+    domain: Option<&str>,
+) -> Cookie<'static> {
+    let mut c = Cookie::build((OAUTH_STATE_COOKIE, value))
         .http_only(true)
         .secure(secure)
         .same_site(SameSite::Lax)
         .path("/auth")
         .max_age(OAUTH_STATE_TTL)
-        .build()
+        .build();
+    if let Some(d) = domain {
+        c.set_domain(d.to_string());
+    }
+    c
 }
 
-pub fn clear_oauth_state_cookie(secure: bool) -> Cookie<'static> {
-    Cookie::build((OAUTH_STATE_COOKIE, ""))
+pub fn clear_oauth_state_cookie(secure: bool, domain: Option<&str>) -> Cookie<'static> {
+    let mut c = Cookie::build((OAUTH_STATE_COOKIE, ""))
         .http_only(true)
         .secure(secure)
         .same_site(SameSite::Lax)
         .path("/auth")
         .max_age(Duration::ZERO)
-        .build()
+        .build();
+    if let Some(d) = domain {
+        c.set_domain(d.to_string());
+    }
+    c
 }

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -13,6 +13,19 @@ pub struct Config {
     /// `true` in production (HTTPS) — sets `Secure` flag on cookies.
     /// `false` in dev (HTTP localhost).
     pub cookie_secure: bool,
+    /// Optional explicit `Domain` attribute on cookies.
+    ///
+    /// - `None` (env var unset) → host-only cookies. The browser only
+    ///   sends them back to the exact host that issued them. This is
+    ///   the right default for dev (FE+BE on `localhost`, port-agnostic
+    ///   so cookies are shared) and for any single-host production.
+    /// - `Some(".stadera.org")` → cookie shared across every subdomain.
+    ///   Required when FE and BE are on different subdomains of a
+    ///   common parent (e.g. `app.stadera.org` + `api.stadera.org`).
+    ///   Browsers reject `Domain` values not matching the host that's
+    ///   setting the cookie, so the value MUST be a parent of the
+    ///   backend's hostname.
+    pub cookie_domain: Option<String>,
     pub google: GoogleConfig,
 }
 
@@ -43,6 +56,13 @@ impl Config {
             .map(|s| s.eq_ignore_ascii_case("true") || s == "1")
             .unwrap_or(false);
 
+        // Treat empty string the same as unset — useful when the env
+        // var is plumbed through CI / deploy infra that always
+        // expands `${{ vars.X }}` even when X has no value.
+        let cookie_domain = std::env::var("COOKIE_DOMAIN")
+            .ok()
+            .filter(|s| !s.is_empty());
+
         let google = GoogleConfig {
             client_id: std::env::var("GOOGLE_CLIENT_ID")
                 .context("GOOGLE_CLIENT_ID env var is required")?,
@@ -57,6 +77,7 @@ impl Config {
             bind_addr,
             frontend_origin,
             cookie_secure,
+            cookie_domain,
             google,
         })
     }

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -42,6 +42,7 @@ async fn start(
     let jar = jar.add(build_oauth_state_cookie(
         csrf.secret().to_string(),
         state.config.cookie_secure,
+        state.config.cookie_domain.as_deref(),
     ));
 
     Ok((jar, Redirect::to(auth_url.as_str())))
@@ -96,11 +97,16 @@ async fn callback(
         .await?;
 
     // 5. Swap cookies: drop the oauth state cookie, set the session cookie.
+    let cookie_domain = state.config.cookie_domain.as_deref();
     let jar = jar
-        .add(clear_oauth_state_cookie(state.config.cookie_secure))
+        .add(clear_oauth_state_cookie(
+            state.config.cookie_secure,
+            cookie_domain,
+        ))
         .add(build_session_cookie(
             session.id.to_string(),
             state.config.cookie_secure,
+            cookie_domain,
         ));
 
     // 6. Hand the user back to the frontend.
@@ -119,6 +125,9 @@ async fn logout(
         let _ = storage.sessions().delete(session_id).await;
     }
 
-    let jar = jar.add(clear_session_cookie(state.config.cookie_secure));
+    let jar = jar.add(clear_session_cookie(
+        state.config.cookie_secure,
+        state.config.cookie_domain.as_deref(),
+    ));
     Ok((jar, Redirect::to(&state.config.frontend_origin)))
 }

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -18,6 +18,7 @@ pub fn test_config() -> Config {
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         frontend_origin: "http://localhost:3000".to_string(),
         cookie_secure: false,
+        cookie_domain: None,
         google: GoogleConfig {
             client_id: "test-client-id".to_string(),
             client_secret: "test-client-secret".to_string(),


### PR DESCRIPTION
When FE and BE deploy as siblings under a custom domain (e.g. app.stadera.org + api.stadera.org), session cookies need an explicit `Domain=.stadera.org` attribute to be visible to both. Without it, the cookie is host-only and the FE's server-side /me gate sees 401 on every navigation → infinite "redirect to landing" loop.

Backwards-compatible: the new `COOKIE_DOMAIN` env var is optional.
- Unset (or empty string) → host-only cookies, identical to current behavior. Right for dev (localhost shared across ports) and for single-host prod (the auto-generated *.run.app deployment).
- Set to `.stadera.org` → Domain attribute on session + oauth state cookies. Browser shares them across all subdomains.

Implementation:
- `Config::cookie_domain: Option<String>`, read from env, empty string treated as None (defensive against CI plumbing that always expands `${{ vars.X }}`).
- All four cookie builders gain a `domain: Option<&str>` parameter. When `None` no `Domain` is set; when `Some(d)` the cookie carries `Domain=d`. Cleared cookies use the same domain so the browser recognizes the deletion.
- Routes propagate `state.config.cookie_domain.as_deref()` to the builders.
- Tests' shared `test_config()` defaults to `cookie_domain: None`.

Workflow + README + walkthrough updated with the new env var, including a "Custom domain mapping" section explaining why the *.run.app cookie isolation is unsolvable without a custom domain (public-suffix list inclusion of `run.app`).
